### PR TITLE
Add recipe control panel and restyle admin UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ rails db:prepare
 ### Jobs
 - `app/jobs/magic_recipe_job.rb` — Background job for AI recipe processing pipeline
 
+### Key Views / Partials
+- `app/views/recipes/_control_panel.html.erb` — Role-aware action bar on recipe#show; renders for the recipe owner (Edit) or any admin (status badge + Edit + Publish/Reject/Reprocess/Delete gated on workflow state)
+- `app/views/admin/recipes/index.html.erb` — Admin recipe list with unified status-filter/action bar
+
 ### Config
 - `config/initializers/content_security_policy.rb` — CSP enforced
 - `config/initializers/acts_as_taggable_on.rb` — Force lowercase tags, auto-cleanup unused tags
@@ -101,6 +105,7 @@ Recipes have a `status` field with values: `draft`, `processing`, `processing_fa
 - Factories in `spec/support/factories.rb`, validated via `spec/models/factories_spec.rb`
 - Shared examples in `spec/support/shared_examples/`
 - Feature specs use Selenium headless Chrome (`js: true`); default driver is `rack_test`
+- `user_logs_in` (in `Features::SessionHelpers`) creates and logs in a regular user; `log_in_as(user)` logs in a pre-created user (use this when you need to supply your own user, e.g. an admin)
 - WebMock disables external network calls in tests
 - `strict_loading_by_default` enabled in test environment to catch N+1 queries
 - Prefer `build_stubbed` over `create` in unit/controller specs for performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,5 @@ Development uses `dotenv-rails` with a `.env` file (see `.sample.env` for requir
 ## CI
 
 GitHub Actions on push to master and all PRs. Runs PostgreSQL 16 service container, Ruby 4.0.1, and `bundle exec rake`.
+
+Always run `bin/rake` locally and confirm it passes before creating a PR.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MilkSteak is a recipe tracker web application built with love.
 - Browse and filter recipes by tags, name, ingredients, and author
 - Autocomplete for tags, ingredients, units, and serving units
 - AI-powered recipe import from URLs or pasted text (admin only, via Anthropic Claude)
+- Role-aware control panel on recipe pages: owners see Edit; admins see status badge and workflow actions (Publish, Reject, Reprocess, Delete)
 - Admin workflow for reviewing, publishing, and rejecting recipes
 - Image uploads with automatic variant generation (thumbnails, large)
 - Pagination and SEO-friendly recipe URLs

--- a/app/views/admin/magic_recipes/new.html.erb
+++ b/app/views/admin/magic_recipes/new.html.erb
@@ -1,33 +1,31 @@
-<div class="max-w-2xl mx-auto p-4 md:p-6">
+<div class="max-w-2xl p-4 md:p-6">
   <h1 class="text-3xl text-ink mb-6">New Magic Recipe</h1>
 
   <% if flash[:alert].present? %>
     <div class="bg-red-50 text-red-700 p-4 rounded-lg mb-6"><%= flash[:alert] %></div>
   <% end %>
 
-  <%= form_tag admin_magic_recipes_path, method: :post, class: 'space-y-6' do %>
-    <div>
-      <p class="text-ink-light mb-4">Paste a recipe URL or raw recipe text. AI will extract the structured recipe data for your review.</p>
+  <%= form_tag admin_magic_recipes_path, method: :post do %>
+    <div class="bg-white rounded-xl px-6 py-6 mb-6 shadow-sm space-y-6">
+      <p class="text-ink-light">Paste a recipe URL or raw recipe text. AI will extract the structured recipe data for your review.</p>
+
+      <div id="source-toggle" class="flex gap-2">
+        <button type="button" data-target="url-input" class="source-toggle-btn px-4 py-2 rounded-lg text-sm bg-terra text-white border-0 cursor-pointer">From URL</button>
+        <button type="button" data-target="text-input" class="source-toggle-btn px-4 py-2 rounded-lg text-sm bg-gray-100 text-gray-700 border-0 cursor-pointer">From Text</button>
+      </div>
+
+      <div id="url-input">
+        <label for="source_url" class="block text-sm font-semibold text-ink mb-1">Recipe URL</label>
+        <input type="url" name="source_url" id="source_url" placeholder="https://example.com/recipe" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-terra/50 focus:border-terra" />
+      </div>
+
+      <div id="text-input" class="hidden">
+        <label for="source_text" class="block text-sm font-semibold text-ink mb-1">Recipe Text</label>
+        <textarea name="source_text" id="source_text" rows="12" placeholder="Paste the recipe text here..." class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-terra/50 focus:border-terra"></textarea>
+      </div>
     </div>
 
-    <div id="source-toggle" class="flex gap-2 mb-4">
-      <button type="button" data-target="url-input" class="source-toggle-btn px-4 py-2 rounded-lg text-sm bg-terra text-white border-0 cursor-pointer">From URL</button>
-      <button type="button" data-target="text-input" class="source-toggle-btn px-4 py-2 rounded-lg text-sm bg-gray-100 text-gray-700 border-0 cursor-pointer">From Text</button>
-    </div>
-
-    <div id="url-input">
-      <label for="source_url" class="block text-sm font-semibold text-ink mb-1">Recipe URL</label>
-      <input type="url" name="source_url" id="source_url" placeholder="https://example.com/recipe" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-terra/50 focus:border-terra" />
-    </div>
-
-    <div id="text-input" class="hidden">
-      <label for="source_text" class="block text-sm font-semibold text-ink mb-1">Recipe Text</label>
-      <textarea name="source_text" id="source_text" rows="12" placeholder="Paste the recipe text here..." class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-terra/50 focus:border-terra"></textarea>
-    </div>
-
-    <div>
-      <input type="submit" value="Create Magic Recipe" class="bg-terra text-white px-6 py-3 rounded-lg border-0 cursor-pointer hover:bg-terra-dark transition-colors font-semibold" />
-    </div>
+    <input type="submit" value="Create Magic Recipe" class="bg-terra text-white px-6 py-3 rounded-lg border-0 cursor-pointer hover:bg-terra-dark transition-colors font-semibold" />
   <% end %>
 </div>
 

--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -1,15 +1,22 @@
 <div class="max-w-6xl mx-auto p-4 md:p-6">
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-3xl text-ink">Admin: Recipes</h1>
-    <%= link_to 'New Magic Recipe', new_admin_magic_recipe_path, class: 'bg-terra text-white px-4 py-2 rounded-lg no-underline hover:bg-terra-dark transition-colors' %>
-  </div>
+  <h1 class="text-3xl text-ink mb-6">Admin: Recipes</h1>
 
-  <div class="flex flex-wrap gap-2 mb-6">
+  <div class="flex items-center gap-x-3 overflow-x-auto bg-white rounded-xl px-5 py-3 shadow-sm border border-cream-dark text-sm mb-6">
+    <% all_active = params[:status].blank? %>
     <%= link_to "All (#{@status_counts.values.sum})", admin_recipes_path,
-        class: "px-3 py-1.5 rounded-full text-sm no-underline #{params[:status].blank? ? 'bg-terra text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        class: ['font-medium no-underline px-2 py-0.5 rounded-md',
+                all_active ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline'].join(' ') %>
     <% Recipe::STATUSES.each do |s| %>
-      <%= link_to "#{s.titleize} (#{@status_counts[s] || 0})", admin_recipes_path(status: s),
-          class: "px-3 py-1.5 rounded-full text-sm no-underline #{params[:status] == s ? 'bg-terra text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% active = params[:status] == s %>
+      <% count = @status_counts[s] || 0 %>
+      <%= link_to "#{s.titleize} (#{count})", admin_recipes_path(status: s),
+          class: ['font-medium no-underline px-2 py-0.5 rounded-md',
+                  active ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline',
+                  count.zero? && !active ? 'opacity-50' : nil].compact.join(' ') %>
+    <% end %>
+    <span class="text-cream-dark">|</span>
+    <%= link_to new_admin_magic_recipe_path, class: 'inline-flex items-center gap-1.5 bg-terra-dark text-white px-3 py-1 rounded-lg no-underline hover:bg-terra font-medium transition-colors' do %>
+      <span class="text-[1.5em] leading-none">🪄</span> New Magic Recipe
     <% end %>
   </div>
 

--- a/app/views/recipes/_control_panel.html.erb
+++ b/app/views/recipes/_control_panel.html.erb
@@ -1,0 +1,32 @@
+<% is_owner = current_user == recipe.user %>
+<% is_admin = current_user&.admin? %>
+<% if is_owner || is_admin %>
+  <div id="control-panel" class="col-span-full flex flex-wrap items-center gap-x-4 gap-y-2 bg-white rounded-xl px-5 py-3 shadow-sm border border-cream-dark text-sm">
+    <% if is_admin %>
+      <div class="flex items-center gap-2">
+        <span class="text-ink-light font-medium">Status:</span>
+        <%= render 'admin/recipes/status_badge', status: recipe.status %>
+      </div>
+      <span class="text-cream-dark">|</span>
+    <% end %>
+
+    <%= link_to 'Edit', edit_recipe_path(recipe), class: 'text-terra hover:underline no-underline font-medium' %>
+
+    <% if is_admin %>
+      <% if recipe.publishable? %>
+        <%= button_to 'Publish', publish_admin_recipe_path(recipe), method: :patch,
+            class: 'text-green-700 hover:underline bg-transparent border-0 cursor-pointer p-0 font-medium' %>
+        <%= button_to 'Reject', reject_admin_recipe_path(recipe), method: :patch,
+            class: 'text-red-700 hover:underline bg-transparent border-0 cursor-pointer p-0 font-medium' %>
+      <% end %>
+      <% if recipe.reprocessable? %>
+        <%= button_to 'Reprocess', reprocess_admin_recipe_path(recipe), method: :patch,
+            class: 'text-orange-700 hover:underline bg-transparent border-0 cursor-pointer p-0 font-medium' %>
+      <% end %>
+      <span class="text-cream-dark">|</span>
+      <%= button_to 'Delete', admin_recipe_path(recipe), method: :delete,
+          class: 'text-red-700 hover:underline bg-transparent border-0 cursor-pointer p-0 font-medium',
+          data: { confirm: 'Are you sure you want to delete this recipe?' } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/recipes/_show_content.html.erb
+++ b/app/views/recipes/_show_content.html.erb
@@ -1,10 +1,9 @@
 <article class="<%= dom_class(recipe) %> grid grid-cols-1 md:grid-cols-[2fr_1fr] lg:grid-cols-[3fr_1fr] gap-6 p-4 md:p-6" id="<%= dom_id(recipe) %>">
+  <%= render 'control_panel', recipe: recipe %>
+
   <div class="recipe-narrative">
     <h1 class="col-span-full text-3xl md:text-4xl mb-4 text-ink">
       <%= recipe.name %>
-      <% if current_user == recipe.user %>
-        <%= link_to('edit', edit_recipe_path(recipe), class: 'text-base align-super text-terra hover:underline') %>
-      <% end %>
     </h1>
 
     <% if recipe.description? %>

--- a/spec/features/admin/recipes_spec.rb
+++ b/spec/features/admin/recipes_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature 'Admin recipe management' do
   let(:admin) { create(:user, :admin) }
+
   before { log_in_as(admin) }
 
   scenario 'status bar includes a link to create a magic recipe' do

--- a/spec/features/admin/recipes_spec.rb
+++ b/spec/features/admin/recipes_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+feature 'Admin recipe management' do
+  let(:admin) { create(:user, :admin) }
+  before { log_in_as(admin) }
+
+  scenario 'status bar includes a link to create a magic recipe' do
+    visit admin_recipes_path
+    expect(page).to have_link('New Magic Recipe', href: new_admin_magic_recipe_path)
+  end
+
+  scenario 'status filter links filter recipes by status' do
+    published = create(:recipe, user: admin)
+    review    = create(:recipe, :review, user: admin)
+
+    visit admin_recipes_path
+    click_link 'Published'
+
+    expect(page).to have_text(published.name)
+    expect(page).not_to have_text(review.name)
+  end
+end

--- a/spec/features/recipe_control_panel_spec.rb
+++ b/spec/features/recipe_control_panel_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+feature 'Recipe control panel' do
+  let(:author) { create(:user) }
+  let(:recipe) { create(:recipe, user: author) }
+
+  context 'when not logged in' do
+    scenario 'does not show any controls' do
+      visit recipe_path(recipe)
+      expect(page).not_to have_css('#control-panel')
+    end
+  end
+
+  context 'when logged in as a non-owner, non-admin user' do
+    scenario 'does not show any controls' do
+      log_in_as(create(:user))
+      visit recipe_path(recipe)
+      expect(page).not_to have_css('#control-panel')
+    end
+  end
+
+  context 'when logged in as the recipe owner' do
+    before { log_in_as(author) }
+
+    scenario 'shows an edit link' do
+      visit recipe_path(recipe)
+      within('#control-panel') do
+        expect(page).to have_link('Edit', href: edit_recipe_path(recipe))
+      end
+    end
+
+    scenario 'does not show admin controls' do
+      visit recipe_path(recipe)
+      within('#control-panel') do
+        expect(page).not_to have_text('Status:')
+        expect(page).not_to have_button('Publish')
+        expect(page).not_to have_button('Reject')
+        expect(page).not_to have_button('Reprocess')
+        expect(page).not_to have_button('Delete')
+      end
+    end
+  end
+
+  context 'when logged in as an admin' do
+    let(:admin) { create(:user, :admin) }
+    before { log_in_as(admin) }
+
+    scenario 'shows the status badge and edit/delete for a published recipe' do
+      visit recipe_path(recipe)
+      within('#control-panel') do
+        expect(page).to have_text('Status:')
+        expect(page).to have_text('published')
+        expect(page).to have_link('Edit', href: edit_recipe_path(recipe))
+        expect(page).to have_button('Delete')
+        expect(page).not_to have_button('Publish')
+        expect(page).not_to have_button('Reject')
+        expect(page).not_to have_button('Reprocess')
+      end
+    end
+
+    context 'with a recipe awaiting review' do
+      let(:recipe) { create(:recipe, :review, user: author) }
+
+      scenario 'shows Publish and Reject but not Reprocess' do
+        visit recipe_path(recipe)
+        within('#control-panel') do
+          expect(page).to have_button('Publish')
+          expect(page).to have_button('Reject')
+          expect(page).not_to have_button('Reprocess')
+        end
+      end
+
+      scenario 'publishing marks the recipe as published' do
+        visit recipe_path(recipe)
+        click_button 'Publish'
+        expect(recipe.reload.status).to eq('published')
+        expect(page).to have_current_path(recipe_path(recipe))
+      end
+
+      scenario 'rejecting marks the recipe as rejected' do
+        visit recipe_path(recipe)
+        click_button 'Reject'
+        expect(recipe.reload.status).to eq('rejected')
+        expect(page).to have_current_path(recipe_path(recipe))
+      end
+    end
+
+    context 'with a processing_failed recipe' do
+      let(:recipe) { create(:recipe, :processing_failed, user: author) }
+
+      scenario 'shows Reprocess but not Publish or Reject' do
+        visit recipe_path(recipe)
+        within('#control-panel') do
+          expect(page).to have_button('Reprocess')
+          expect(page).not_to have_button('Publish')
+          expect(page).not_to have_button('Reject')
+        end
+      end
+
+      scenario 'reprocessing enqueues a MagicRecipeJob' do
+        allow(MagicRecipeJob).to receive(:perform_later)
+        visit recipe_path(recipe)
+        click_button 'Reprocess'
+        expect(MagicRecipeJob).to have_received(:perform_later).with(recipe.id)
+      end
+    end
+
+    context 'with a draft recipe' do
+      let(:recipe) { create(:recipe, :draft, user: author) }
+
+      scenario 'shows only edit and delete' do
+        visit recipe_path(recipe)
+        within('#control-panel') do
+          expect(page).to have_link('Edit')
+          expect(page).to have_button('Delete')
+          expect(page).not_to have_button('Publish')
+          expect(page).not_to have_button('Reject')
+          expect(page).not_to have_button('Reprocess')
+        end
+      end
+    end
+
+    scenario 'deleting a recipe destroys it and redirects to admin index' do
+      visit recipe_path(recipe)
+      click_button 'Delete'
+      expect(Recipe.find_by(id: recipe.id)).to be_nil
+      expect(page).to have_current_path(admin_recipes_path)
+    end
+  end
+end

--- a/spec/features/recipe_control_panel_spec.rb
+++ b/spec/features/recipe_control_panel_spec.rb
@@ -43,15 +43,22 @@ feature 'Recipe control panel' do
 
   context 'when logged in as an admin' do
     let(:admin) { create(:user, :admin) }
+
     before { log_in_as(admin) }
 
-    scenario 'shows the status badge and edit/delete for a published recipe' do
+    scenario 'shows the status badge, edit, and delete for a published recipe' do
       visit recipe_path(recipe)
       within('#control-panel') do
         expect(page).to have_text('Status:')
         expect(page).to have_text('published')
         expect(page).to have_link('Edit', href: edit_recipe_path(recipe))
         expect(page).to have_button('Delete')
+      end
+    end
+
+    scenario 'does not show workflow buttons for a published recipe' do
+      visit recipe_path(recipe)
+      within('#control-panel') do
         expect(page).not_to have_button('Publish')
         expect(page).not_to have_button('Reject')
         expect(page).not_to have_button('Reprocess')

--- a/spec/features/user_manages_recipes_spec.rb
+++ b/spec/features/user_manages_recipes_spec.rb
@@ -34,7 +34,7 @@ feature 'User manages recipes', js: true do
 
     click_on 'Test recipe'
 
-    click_on 'edit'
+    click_on 'Edit'
 
     recipe_on_page.fill_in_main_form_with(
       'Name' => 'Updated Test recipe'

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -1,5 +1,12 @@
 module Features
   module SessionHelpers
+    def log_in_as(user)
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      within('form#new_user') { click_on 'Log in' }
+    end
+
     def user_logs_in
       # TODO - create user in the main thread
       # This right here is why the build fails on integration specs sometimes


### PR DESCRIPTION
## Summary

- Adds a role-aware control panel to `recipe#show`: recipe owners see an Edit link; admins see a status badge plus workflow action buttons (Publish, Reject, Reprocess, Delete) gated on the recipe's current status
- Restyls the admin recipes index status bar into a unified control-panel-style card with subtle active highlights and 50% opacity for empty statuses; moves the New Magic Recipe button into the same bar
- Wraps the admin magic recipes new page form in a white rounded card matching the recipe show ingredient list; left-aligns the page

## Test plan

- [ ] Visit a published recipe as a guest — no control panel shown
- [ ] Visit a published recipe as the owner — Edit link appears, no admin controls
- [ ] Visit a recipe as an admin — status badge, Edit, Delete visible; Publish/Reject only on `review` recipes; Reprocess only on `processing_failed`
- [ ] Confirm clicking Publish/Reject/Reprocess/Delete on recipe show works correctly
- [ ] Visit admin recipes index — status filter bar and New Magic Recipe button render in unified card; active status is highlighted; zero-count statuses are faded
- [ ] Visit admin magic recipes new — form body appears in a rounded white card
- [ ] `bundle exec rspec` passes