### PR TITLE
Separate ingredient descriptors from canonical names

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -69,7 +69,7 @@ class RecipesController < ApplicationController
       :course_list,
       :dietary_restriction_list,
       { images_attributes: [:_destroy, :id, :caption, :featured, :image],
-        recipe_ingredients_attributes: [:_destroy, :id, :quantity, :unit, :section,
+        recipe_ingredients_attributes: [:_destroy, :id, :quantity, :unit, :section, :descriptor,
                                         { ingredient_attributes: [:id, :name] }] }
     ]
     permitted.push(:source_url, :source_text, :status) if current_user&.admin?

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -14,6 +14,9 @@ class RecipeIngredient < ApplicationRecord
   validates :section,
     allow_blank: true,
     length: { maximum: 255 }
+  validates :descriptor,
+    allow_blank: true,
+    length: { maximum: 255 }
 
   accepts_nested_attributes_for :ingredient,
     reject_if: ->(attr) { attr['name'].blank? }

--- a/app/services/recipe_ai_applier.rb
+++ b/app/services/recipe_ai_applier.rb
@@ -39,6 +39,7 @@ class RecipeAiApplier
         quantity: ing_data['quantity'],
         unit: ing_data['unit'],
         section: ing_data['section'],
+        descriptor: ing_data['descriptor'],
         position: index + 1
       )
     end

--- a/app/services/recipe_ai_extractor.rb
+++ b/app/services/recipe_ai_extractor.rb
@@ -13,7 +13,7 @@ class RecipeAiExtractor
       "servings": null or integer,
       "serving_units": "e.g. servings, cups, pieces" or null,
       "ingredients": [
-        {"quantity": "1", "unit": "cup", "name": "flour", "section": "Crust"}
+        {"quantity": "1", "unit": "cup", "name": "flour", "descriptor": "sifted", "section": "Crust"}
       ],
       "cooking_methods": ["bake", "saute"],
       "cultural_influences": ["italian"],
@@ -22,8 +22,8 @@ class RecipeAiExtractor
     }
 
     Ingredients:
-    - Names should be lowercase and simple, strip specific brand names
-    - Include preparation modifiers in the name (e.g. "onion, diced", "garlic, minced") rather than the unit
+    - Names should be the plain canonical ingredient only, lowercase (e.g. "onion", "garlic", "tomato"). No prep verbs, no quality adjectives, strip specific brand names
+    - Put any preparation method or quality descriptor in the separate `descriptor` field, lowercase (e.g. "diced", "minced", "ripe", "fresh", "crushed"). Omit the field (or use null) if there is no descriptor
     - Quantity should be a string that can include fractions like "1/2". Use "to taste" when no specific amount is given
     - Unit should be a standard measurement (cup, tbsp, tsp, oz, lb, etc.) or empty string when not applicable (e.g. "2" "large" "eggs")
     - Every ingredient in the list MUST be referenced in the directions. If the source text mentions an ingredient only in the directions but not in the ingredient list, add it to the ingredients list

--- a/app/views/recipe_ingredients/_recipe_ingredient.html.erb
+++ b/app/views/recipe_ingredients/_recipe_ingredient.html.erb
@@ -1,5 +1,5 @@
 <li class="<%= dom_class(recipe_ingredient) %> py-1.5 border-b border-cream-dark/50 last:border-b-0" id="<%= dom_id(recipe_ingredient) %>">
   <span class="quantity font-semibold text-ink"><%= recipe_ingredient.quantity.to_s.sub(/\.0$/,'') %></span>
   <span class="unit text-ink-muted"><%= recipe_ingredient.unit %></span>
-  <span class="name text-ink-light"><%= link_to(recipe_ingredient.name, root_path(filter_set: { ingredients: recipe_ingredient.name }), class: 'text-ink-light no-underline hover:text-terra hover:underline') %></span>
+  <span class="name text-ink-light"><%= link_to(recipe_ingredient.name, root_path(filter_set: { ingredients: recipe_ingredient.name }), class: 'text-ink-light no-underline hover:text-terra hover:underline') %><% if recipe_ingredient.descriptor.present? %><span class="text-ink-muted">, <%= recipe_ingredient.descriptor %></span><% end %></span>
 </li>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -47,7 +47,7 @@
           Section
         </div>
         <div class="recipe_recipe_ingredients_ingredient_name header font-semibold text-xs text-ink-muted uppercase tracking-wide">
-          Name
+          Name &amp; Descriptor
         </div>
       </div>
       <%= f.simple_fields_for :recipe_ingredients do |ri_form| %>
@@ -63,12 +63,24 @@
             'data-target' => autocompletes_ingredient_units_path
           }%>
           <%= ri_form.input :section, label: false %>
-          <%= ri_form.simple_fields_for :ingredient do |i_form| %>
-            <%= i_form.input :name, required: false, label: false, input_html: {
-              class: 'autocomplete_single',
-              'data-target' => autocompletes_ingredient_names_path
-            }%>
-          <% end %>
+          <div class="flex gap-1 items-start">
+            <div class="flex-auto min-w-0">
+              <%= ri_form.simple_fields_for :ingredient do |i_form| %>
+                <%= i_form.input :name, required: false, label: false, input_html: {
+                  class: 'autocomplete_single',
+                  placeholder: 'tomato, cheddar cheese, bread flour . . .',
+                  'data-target' => autocompletes_ingredient_names_path
+                }%>
+              <% end %>
+            </div>
+            <span class="text-ink-muted mt-2 shrink-0">,</span>
+            <div class="w-2/5 shrink-0">
+              <%= ri_form.input :descriptor, label: false, input_html: {
+                placeholder: 'shredded, ripe, minced . . .',
+                class: 'text-ink-muted'
+              } %>
+            </div>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -73,7 +73,6 @@
                 }%>
               <% end %>
             </div>
-            <span class="text-ink-muted mt-2 shrink-0">,</span>
             <div class="w-2/5 shrink-0">
               <%= ri_form.input :descriptor, label: false, input_html: {
                 placeholder: 'shredded, ripe, minced . . .',

--- a/db/migrate/20260220163302_add_descriptor_to_recipe_ingredients.rb
+++ b/db/migrate/20260220163302_add_descriptor_to_recipe_ingredients.rb
@@ -1,0 +1,5 @@
+class AddDescriptorToRecipeIngredients < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recipe_ingredients, :descriptor, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_18_193729) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_20_163302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_18_193729) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "section", limit: 255
+    t.string "descriptor", limit: 255
     t.index ["ingredient_id"], name: "index_recipe_ingredients_on_ingredient_id"
     t.index ["position"], name: "index_recipe_ingredients_on_position"
     t.index ["recipe_id", "ingredient_id"], name: "index_recipe_ingredients_on_recipe_id_and_ingredient_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,6 +21,15 @@ def attach_seed_image(recipe, filename, caption: nil, featured: true)
   image.save!
 end
 
+def ri(name, quantity:, unit:, descriptor: nil)
+  RecipeIngredient.new(
+    quantity: quantity,
+    unit: unit,
+    descriptor: descriptor,
+    ingredient: Ingredient.where(name: name).first_or_create!
+  )
+end
+
 if Rails.env == 'development'
   admin = User.find_or_initialize_by(email: 'admin@example.com')
   if admin.new_record?
@@ -44,10 +53,7 @@ if Rails.env == 'development'
     directions: 'Pour water in ice cube tray. Freeze',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(
-        quantity: 1, unit: 'quart',
-        ingredient: Ingredient.where(name: 'water').first_or_create!
-      )
+      ri('water', quantity: 1, unit: 'quart')
     ]
   )
   attach_seed_image(recipe, 'ice.jpg', caption: 'Ice cubes')
@@ -68,34 +74,13 @@ Saute garlic for 5 minutes until it starts to get sticky.
 Pour in tomatoes and stir quickly into garlic oil. Bring to a boil and reduce heat to low. Put in all spices and simmer until done, 1/2 hour to an hour. Serve over pasta or use in other recipes.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(
-        quantity: 6, unit: 'cloves',
-        ingredient: Ingredient.where(name: 'Garlic').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 1, unit: '22 oz can',
-        ingredient: Ingredient.where(name: 'Crushed tomatoes').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 0.25, unit: 'cup',
-        ingredient: Ingredient.where(name: 'Chopped basil').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 0.125, unit: 'cup',
-        ingredient: Ingredient.where(name: 'Chopped oregano').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 1, unit: 'tsp',
-        ingredient: Ingredient.where(name: 'salt').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 0.5, unit: 'tsp',
-        ingredient: Ingredient.where(name: 'ground black pepper').first_or_create!
-      ),
-      RecipeIngredient.new(
-        quantity: 0.125, unit: 'tsp',
-        ingredient: Ingredient.where(name: 'cayenne pepper').first_or_create!
-      ),
+      ri('garlic', quantity: 6, unit: 'cloves'),
+      ri('tomatoes', quantity: 1, unit: '22 oz can', descriptor: 'crushed'),
+      ri('basil', quantity: 0.25, unit: 'cup', descriptor: 'chopped'),
+      ri('oregano', quantity: 0.125, unit: 'cup', descriptor: 'chopped'),
+      ri('salt', quantity: 1, unit: 'tsp'),
+      ri('black pepper', quantity: 0.5, unit: 'tsp', descriptor: 'ground'),
+      ri('cayenne pepper', quantity: 0.125, unit: 'tsp'),
     ]
   )
   attach_seed_image(recipe, 'marinara_sauce.jpg', caption: 'Homemade marinara sauce')
@@ -120,18 +105,18 @@ In a large skillet, heat butter and saute onion until soft. Add garlic and ginge
 Stir in cream and the roasted chicken. Simmer 10 minutes. Finish with fresh cilantro and serve over basmati rice.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1.5, unit: 'lbs', ingredient: Ingredient.where(name: 'boneless chicken thighs').first_or_create!),
-      RecipeIngredient.new(quantity: 0.75, unit: 'cup', ingredient: Ingredient.where(name: 'plain yogurt').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'lemon juice').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tsp', ingredient: Ingredient.where(name: 'garam masala').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'large', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'fresh ginger').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: '14 oz can', ingredient: Ingredient.where(name: 'Crushed tomatoes').first_or_create!),
-      RecipeIngredient.new(quantity: 0.75, unit: 'cup', ingredient: Ingredient.where(name: 'heavy cream').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'butter').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'fresh cilantro').first_or_create!),
+      ri('chicken thighs', quantity: 1.5, unit: 'lbs', descriptor: 'boneless'),
+      ri('yogurt', quantity: 0.75, unit: 'cup', descriptor: 'plain'),
+      ri('lemon juice', quantity: 1, unit: 'tbsp'),
+      ri('garam masala', quantity: 2, unit: 'tsp'),
+      ri('cumin', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('yellow onion', quantity: 1, unit: 'large'),
+      ri('garlic', quantity: 3, unit: 'cloves'),
+      ri('ginger', quantity: 1, unit: 'tbsp', descriptor: 'fresh'),
+      ri('tomatoes', quantity: 1, unit: '14 oz can', descriptor: 'crushed'),
+      ri('heavy cream', quantity: 0.75, unit: 'cup'),
+      ri('butter', quantity: 2, unit: 'tbsp'),
+      ri('cilantro', quantity: 0.25, unit: 'cup', descriptor: 'fresh'),
     ]
   )
   attach_seed_image(recipe, 'chicken_tikka_masala.jpg', caption: 'Chicken tikka masala with rice')
@@ -154,14 +139,14 @@ Fold in diced onion, tomato, jalapeno, cilantro, and lime juice. Season with sal
 Serve immediately with tortilla chips or as a topping.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 3, unit: 'medium', ingredient: Ingredient.where(name: 'ripe avocados').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'small', ingredient: Ingredient.where(name: 'white onion').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'medium', ingredient: Ingredient.where(name: 'roma tomato').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'small', ingredient: Ingredient.where(name: 'jalapeno').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'fresh cilantro').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'lime juice').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'salt').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
+      ri('avocados', quantity: 3, unit: 'medium', descriptor: 'ripe'),
+      ri('white onion', quantity: 0.5, unit: 'small'),
+      ri('roma tomato', quantity: 1, unit: 'medium'),
+      ri('jalapeno', quantity: 1, unit: 'small'),
+      ri('cilantro', quantity: 0.25, unit: 'cup', descriptor: 'fresh'),
+      ri('lime juice', quantity: 2, unit: 'tbsp'),
+      ri('salt', quantity: 0.5, unit: 'tsp'),
+      ri('cumin', quantity: 0.25, unit: 'tsp', descriptor: 'ground'),
     ]
   )
   attach_seed_image(recipe, 'guacamole.jpg', caption: 'Fresh guacamole with chips')
@@ -184,10 +169,10 @@ Toast freshly cracked black pepper in a dry skillet over medium heat for 1-2 min
 Add the drained pasta and toss vigorously. Remove from heat and add Pecorino Romano a handful at a time, tossing constantly and adding splashes of pasta water to create a creamy sauce. Serve immediately with extra cheese and pepper.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1, unit: 'lb', ingredient: Ingredient.where(name: 'spaghetti').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'cups', ingredient: Ingredient.where(name: 'Pecorino Romano').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'whole black peppercorns').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'salt').first_or_create!),
+      ri('spaghetti', quantity: 1, unit: 'lb'),
+      ri('pecorino romano', quantity: 2, unit: 'cups'),
+      ri('black peppercorns', quantity: 1, unit: 'tbsp', descriptor: 'whole'),
+      ri('salt', quantity: 1, unit: 'tsp'),
     ]
   )
   attach_seed_image(recipe, 'cacio_e_pepe.jpg', caption: 'Cacio e pepe with fresh pepper')
@@ -210,19 +195,19 @@ Stir in cumin, coriander, turmeric, garam masala, and chili powder. Toast spices
 Add drained chickpeas and 1 cup water. Simmer 20 minutes until sauce thickens. Stir in lemon juice and cilantro. Season with salt. Serve with rice or naan.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 2, unit: '15 oz cans', ingredient: Ingredient.where(name: 'chickpeas').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'large', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 4, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'fresh ginger').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'small', ingredient: Ingredient.where(name: 'serrano pepper').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: '14 oz can', ingredient: Ingredient.where(name: 'diced tomatoes').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground coriander').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'ground turmeric').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'garam masala').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'vegetable oil').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'lemon juice').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'fresh cilantro').first_or_create!),
+      ri('chickpeas', quantity: 2, unit: '15 oz cans'),
+      ri('yellow onion', quantity: 1, unit: 'large'),
+      ri('garlic', quantity: 4, unit: 'cloves'),
+      ri('ginger', quantity: 1, unit: 'tbsp', descriptor: 'fresh'),
+      ri('serrano pepper', quantity: 1, unit: 'small'),
+      ri('tomatoes', quantity: 1, unit: '14 oz can', descriptor: 'diced'),
+      ri('cumin', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('coriander', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('turmeric', quantity: 0.5, unit: 'tsp', descriptor: 'ground'),
+      ri('garam masala', quantity: 1, unit: 'tsp'),
+      ri('vegetable oil', quantity: 2, unit: 'tbsp'),
+      ri('lemon juice', quantity: 2, unit: 'tbsp'),
+      ri('cilantro', quantity: 0.25, unit: 'cup', descriptor: 'fresh'),
     ]
   )
   attach_seed_image(recipe, 'chana_masala.jpg', caption: 'Chana masala with naan')
@@ -247,16 +232,16 @@ Uncover, increase heat to medium-high, and cook until liquid evaporates and pork
 Alternatively, spread shredded pork on a sheet pan and broil 3-5 minutes until edges are crispy. Serve in warm tortillas with onion, cilantro, and salsa verde.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 3, unit: 'lbs', ingredient: Ingredient.where(name: 'pork shoulder').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'large', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 5, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'orange juice').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'lime juice').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'dried oregano').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'whole', ingredient: Ingredient.where(name: 'bay leaves').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'salt').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'ground black pepper').first_or_create!),
+      ri('pork shoulder', quantity: 3, unit: 'lbs'),
+      ri('yellow onion', quantity: 1, unit: 'large'),
+      ri('garlic', quantity: 5, unit: 'cloves'),
+      ri('orange juice', quantity: 0.5, unit: 'cup'),
+      ri('lime juice', quantity: 2, unit: 'tbsp'),
+      ri('cumin', quantity: 1, unit: 'tbsp', descriptor: 'ground'),
+      ri('oregano', quantity: 1, unit: 'tbsp', descriptor: 'dried'),
+      ri('bay leaves', quantity: 2, unit: 'whole'),
+      ri('salt', quantity: 1, unit: 'tsp'),
+      ri('black pepper', quantity: 0.5, unit: 'tsp', descriptor: 'ground'),
     ]
   )
   attach_seed_image(recipe, 'carnitas.jpg', caption: 'Crispy carnitas tacos')
@@ -281,18 +266,18 @@ In the same pan, heat butter. Add cumin seeds and let them sputter. Add onion an
 Add the spinach puree and simmer 5 minutes. Stir in cream and the fried paneer. Cook 5 minutes more. Season with salt and serve with naan or rice.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1, unit: 'lb', ingredient: Ingredient.where(name: 'fresh spinach').first_or_create!),
-      RecipeIngredient.new(quantity: 8, unit: 'oz', ingredient: Ingredient.where(name: 'paneer').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'medium', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'inch piece', ingredient: Ingredient.where(name: 'fresh ginger').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'small', ingredient: Ingredient.where(name: 'green chili').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground coriander').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'ground turmeric').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'garam masala').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'butter').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'heavy cream').first_or_create!),
+      ri('spinach', quantity: 1, unit: 'lb', descriptor: 'fresh'),
+      ri('paneer', quantity: 8, unit: 'oz'),
+      ri('yellow onion', quantity: 1, unit: 'medium'),
+      ri('garlic', quantity: 3, unit: 'cloves'),
+      ri('ginger', quantity: 1, unit: 'inch piece', descriptor: 'fresh'),
+      ri('green chili', quantity: 1, unit: 'small'),
+      ri('cumin', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('coriander', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('turmeric', quantity: 0.5, unit: 'tsp', descriptor: 'ground'),
+      ri('garam masala', quantity: 1, unit: 'tsp'),
+      ri('butter', quantity: 2, unit: 'tbsp'),
+      ri('heavy cream', quantity: 0.25, unit: 'cup'),
     ]
   )
   attach_seed_image(recipe, 'palak_paneer.jpg', caption: 'Palak paneer with rice')
@@ -317,16 +302,16 @@ Shred cooked chicken and mix with half the sauce and diced onion. Briefly fry co
 Pour remaining sauce over enchiladas, top with crumbled queso fresco, and bake at 375F for 20 minutes. Garnish with cilantro and crema.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 2, unit: 'cups', ingredient: Ingredient.where(name: 'shredded chicken').first_or_create!),
-      RecipeIngredient.new(quantity: 6, unit: 'whole', ingredient: Ingredient.where(name: 'dried guajillo chiles').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'whole', ingredient: Ingredient.where(name: 'dried ancho chiles').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 12, unit: 'whole', ingredient: Ingredient.where(name: 'corn tortillas').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'queso fresco').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'dried oregano').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'medium', ingredient: Ingredient.where(name: 'white onion').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'tbsp', ingredient: Ingredient.where(name: 'vegetable oil').first_or_create!),
+      ri('chicken', quantity: 2, unit: 'cups', descriptor: 'shredded'),
+      ri('guajillo chiles', quantity: 6, unit: 'whole', descriptor: 'dried'),
+      ri('ancho chiles', quantity: 2, unit: 'whole', descriptor: 'dried'),
+      ri('garlic', quantity: 3, unit: 'cloves'),
+      ri('corn tortillas', quantity: 12, unit: 'whole'),
+      ri('queso fresco', quantity: 0.5, unit: 'cup'),
+      ri('cumin', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('oregano', quantity: 1, unit: 'tsp', descriptor: 'dried'),
+      ri('white onion', quantity: 0.5, unit: 'medium'),
+      ri('vegetable oil', quantity: 3, unit: 'tbsp'),
     ]
   )
   attach_seed_image(recipe, 'enchiladas_rojas.jpg', caption: 'Enchiladas rojas with queso fresco')
@@ -351,14 +336,14 @@ Add wine and stir until absorbed. Add warm broth one ladle at a time, stirring f
 Stir in the saffron broth, remaining butter, and Parmigiano-Reggiano. Season with salt and pepper. Cover and rest 2 minutes before serving.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1.5, unit: 'cups', ingredient: Ingredient.where(name: 'arborio rice').first_or_create!),
-      RecipeIngredient.new(quantity: 5, unit: 'cups', ingredient: Ingredient.where(name: 'vegetable broth').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'tsp', ingredient: Ingredient.where(name: 'saffron threads').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'small', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'dry white wine').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'tbsp', ingredient: Ingredient.where(name: 'butter').first_or_create!),
-      RecipeIngredient.new(quantity: 0.75, unit: 'cup', ingredient: Ingredient.where(name: 'Parmigiano-Reggiano').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'salt').first_or_create!),
+      ri('arborio rice', quantity: 1.5, unit: 'cups'),
+      ri('vegetable broth', quantity: 5, unit: 'cups'),
+      ri('saffron threads', quantity: 0.25, unit: 'tsp'),
+      ri('yellow onion', quantity: 1, unit: 'small'),
+      ri('dry white wine', quantity: 0.5, unit: 'cup'),
+      ri('butter', quantity: 3, unit: 'tbsp'),
+      ri('parmigiano-reggiano', quantity: 0.75, unit: 'cup'),
+      ri('salt', quantity: 1, unit: 'tsp'),
     ]
   )
   attach_seed_image(recipe, 'risotto.jpg', caption: 'Saffron risotto alla milanese')
@@ -383,19 +368,19 @@ Add diced onion and cook until golden. Add garlic, ginger, and tomato, cook 3 mi
 Pour the tadka over the cooked dal and stir well. Simmer together 5 minutes. Finish with fresh cilantro and a squeeze of lemon. Serve over rice.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1, unit: 'cup', ingredient: Ingredient.where(name: 'toor dal').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cups', ingredient: Ingredient.where(name: 'water').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'ground turmeric').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'mustard seeds').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'cumin seeds').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'whole', ingredient: Ingredient.where(name: 'dried red chiles').first_or_create!),
-      RecipeIngredient.new(quantity: 8, unit: 'leaves', ingredient: Ingredient.where(name: 'curry leaves').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'medium', ingredient: Ingredient.where(name: 'yellow onion').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'fresh ginger').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'medium', ingredient: Ingredient.where(name: 'roma tomato').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'vegetable oil').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'fresh cilantro').first_or_create!),
+      ri('toor dal', quantity: 1, unit: 'cup'),
+      ri('water', quantity: 3, unit: 'cups'),
+      ri('turmeric', quantity: 0.5, unit: 'tsp', descriptor: 'ground'),
+      ri('mustard seeds', quantity: 1, unit: 'tsp'),
+      ri('cumin seeds', quantity: 1, unit: 'tsp'),
+      ri('red chiles', quantity: 2, unit: 'whole', descriptor: 'dried'),
+      ri('curry leaves', quantity: 8, unit: 'leaves'),
+      ri('yellow onion', quantity: 1, unit: 'medium'),
+      ri('garlic', quantity: 3, unit: 'cloves'),
+      ri('ginger', quantity: 1, unit: 'tbsp', descriptor: 'fresh'),
+      ri('roma tomato', quantity: 1, unit: 'medium'),
+      ri('vegetable oil', quantity: 2, unit: 'tbsp'),
+      ri('cilantro', quantity: 0.25, unit: 'cup', descriptor: 'fresh'),
     ]
   )
   attach_seed_image(recipe, 'dal_tadka.jpg', caption: 'Dal tadka with tempered spices')
@@ -418,13 +403,13 @@ Mix mayonnaise and crema together. While corn is still hot, brush generously wit
 Roll corn in crumbled cotija cheese, then dust with chili powder. Sprinkle with fresh cilantro and serve immediately with lime wedges.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 4, unit: 'ears', ingredient: Ingredient.where(name: 'corn on the cob').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'mayonnaise').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'Mexican crema').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'cotija cheese').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'chili powder').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'lime juice').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'fresh cilantro').first_or_create!),
+      ri('corn on the cob', quantity: 4, unit: 'ears'),
+      ri('mayonnaise', quantity: 0.25, unit: 'cup'),
+      ri('mexican crema', quantity: 0.25, unit: 'cup'),
+      ri('cotija cheese', quantity: 0.5, unit: 'cup'),
+      ri('chili powder', quantity: 1, unit: 'tsp'),
+      ri('lime juice', quantity: 2, unit: 'tbsp'),
+      ri('cilantro', quantity: 2, unit: 'tbsp', descriptor: 'fresh'),
     ]
   )
   attach_seed_image(recipe, 'elote.jpg', caption: 'Grilled Mexican street corn')
@@ -448,16 +433,16 @@ Pour in vodka carefully and cook until reduced by half, about 2 minutes. Add cru
 Reduce heat to low and stir in heavy cream. Add the drained pasta and toss, adding pasta water as needed. Finish with Parmigiano-Reggiano and fresh basil.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 1, unit: 'lb', ingredient: Ingredient.where(name: 'penne').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'olive oil').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'tsp', ingredient: Ingredient.where(name: 'red pepper flakes').first_or_create!),
-      RecipeIngredient.new(quantity: 3, unit: 'tbsp', ingredient: Ingredient.where(name: 'tomato paste').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'vodka').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: '14 oz can', ingredient: Ingredient.where(name: 'Crushed tomatoes').first_or_create!),
-      RecipeIngredient.new(quantity: 0.75, unit: 'cup', ingredient: Ingredient.where(name: 'heavy cream').first_or_create!),
-      RecipeIngredient.new(quantity: 0.5, unit: 'cup', ingredient: Ingredient.where(name: 'Parmigiano-Reggiano').first_or_create!),
-      RecipeIngredient.new(quantity: 0.25, unit: 'cup', ingredient: Ingredient.where(name: 'Chopped basil').first_or_create!),
+      ri('penne', quantity: 1, unit: 'lb'),
+      ri('olive oil', quantity: 2, unit: 'tbsp'),
+      ri('garlic', quantity: 3, unit: 'cloves'),
+      ri('red pepper flakes', quantity: 0.5, unit: 'tsp'),
+      ri('tomato paste', quantity: 3, unit: 'tbsp'),
+      ri('vodka', quantity: 0.5, unit: 'cup'),
+      ri('tomatoes', quantity: 1, unit: '14 oz can', descriptor: 'crushed'),
+      ri('heavy cream', quantity: 0.75, unit: 'cup'),
+      ri('parmigiano-reggiano', quantity: 0.5, unit: 'cup'),
+      ri('basil', quantity: 0.25, unit: 'cup', descriptor: 'fresh'),
     ]
   )
   attach_seed_image(recipe, 'penne_alla_vodka.jpg', caption: 'Penne alla vodka with basil')
@@ -482,16 +467,16 @@ In the pot, heat oil and fry the chile sauce for 5 minutes. Add reserved broth, 
 Serve in bowls with shredded cabbage, sliced radishes, diced onion, dried oregano, lime wedges, and tostadas.',
     user: admin,
     recipe_ingredients: [
-      RecipeIngredient.new(quantity: 2, unit: 'lbs', ingredient: Ingredient.where(name: 'pork shoulder').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: '29 oz can', ingredient: Ingredient.where(name: 'hominy').first_or_create!),
-      RecipeIngredient.new(quantity: 5, unit: 'whole', ingredient: Ingredient.where(name: 'dried guajillo chiles').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'whole', ingredient: Ingredient.where(name: 'dried ancho chiles').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'large', ingredient: Ingredient.where(name: 'white onion').first_or_create!),
-      RecipeIngredient.new(quantity: 5, unit: 'cloves', ingredient: Ingredient.where(name: 'Garlic').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'whole', ingredient: Ingredient.where(name: 'bay leaves').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tsp', ingredient: Ingredient.where(name: 'ground cumin').first_or_create!),
-      RecipeIngredient.new(quantity: 1, unit: 'tbsp', ingredient: Ingredient.where(name: 'dried oregano').first_or_create!),
-      RecipeIngredient.new(quantity: 2, unit: 'tbsp', ingredient: Ingredient.where(name: 'vegetable oil').first_or_create!),
+      ri('pork shoulder', quantity: 2, unit: 'lbs'),
+      ri('hominy', quantity: 1, unit: '29 oz can'),
+      ri('guajillo chiles', quantity: 5, unit: 'whole', descriptor: 'dried'),
+      ri('ancho chiles', quantity: 2, unit: 'whole', descriptor: 'dried'),
+      ri('white onion', quantity: 1, unit: 'large'),
+      ri('garlic', quantity: 5, unit: 'cloves'),
+      ri('bay leaves', quantity: 2, unit: 'whole'),
+      ri('cumin', quantity: 1, unit: 'tsp', descriptor: 'ground'),
+      ri('oregano', quantity: 1, unit: 'tbsp', descriptor: 'dried'),
+      ri('vegetable oil', quantity: 2, unit: 'tbsp'),
     ]
   )
   attach_seed_image(recipe, 'pozole_rojo.jpg', caption: 'Pozole rojo with garnishes')

--- a/spec/models/recipe_ingredient_spec.rb
+++ b/spec/models/recipe_ingredient_spec.rb
@@ -9,6 +9,7 @@ describe RecipeIngredient do
   it { should validate_length_of(:quantity).is_at_most(10) }
   it { should validate_length_of(:unit).is_at_most(255) }
   it { should validate_length_of(:section).is_at_most(255) }
+  it { should validate_length_of(:descriptor).is_at_most(255) }
 
   it "delegates name to ingredient" do
     recipe_ingredient = build(:recipe_ingredient)

--- a/spec/services/recipe_ai_applier_spec.rb
+++ b/spec/services/recipe_ai_applier_spec.rb
@@ -13,7 +13,7 @@ describe RecipeAiApplier do
       'servings' => 8,
       'serving_units' => 'slices',
       'ingredients' => [
-        { 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour', 'section' => 'Dry' },
+        { 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour', 'descriptor' => 'sifted', 'section' => 'Dry' },
         { 'quantity' => '1', 'unit' => 'cup', 'name' => 'sugar', 'section' => 'Dry' },
         { 'quantity' => '2', 'unit' => 'large', 'name' => 'eggs', 'section' => 'Wet' }
       ],
@@ -66,6 +66,16 @@ describe RecipeAiApplier do
       recipe.reload
       sections = recipe.recipe_ingredients.order(:position).map(&:section)
       expect(sections).to eq(%w[Dry Dry Wet])
+    end
+
+    it 'assigns descriptors to recipe ingredients' do
+      described_class.apply(recipe, data)
+
+      recipe.reload
+      flour_ri = recipe.recipe_ingredients.joins(:ingredient).find_by(ingredients: { name: 'flour' })
+      sugar_ri = recipe.recipe_ingredients.joins(:ingredient).find_by(ingredients: { name: 'sugar' })
+      expect(flour_ri.descriptor).to eq('sifted')
+      expect(sugar_ri.descriptor).to be_nil
     end
 
     it 'sets tag lists' do

--- a/spec/services/recipe_ai_extractor_spec.rb
+++ b/spec/services/recipe_ai_extractor_spec.rb
@@ -8,7 +8,7 @@ describe RecipeAiExtractor do
       {
         'name' => 'Chocolate Cake',
         'directions' => '1. Mix ingredients',
-        'ingredients' => [{ 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour' }]
+        'ingredients' => [{ 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour', 'descriptor' => 'sifted' }]
       }
     end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -80,5 +80,6 @@ FactoryBot.define do
   factory :recipe_ingredient do
     recipe
     ingredient
+    descriptor { nil }
   end
 end


### PR DESCRIPTION
## Summary

- Adds a `descriptor` field to `RecipeIngredient` for prep/quality modifiers (e.g. "crushed", "minced", "fresh"), keeping `Ingredient.name` as a clean canonical lookup key
- Updates the AI extractor prompt to emit canonical names and a separate `descriptor`, and wires it through the applier
- Shows `name, descriptor` on recipe pages; adds an inline descriptor input alongside the name autocomplete in the ingredient form
- Normalizes all seed ingredient names (e.g. `'Crushed tomatoes'` → name: `'tomatoes'`, descriptor: `'crushed'`)

## Test plan

- [ ] `bin/rake` passes
- [ ] `rails db:seed` runs without error; inspect a few ingredients to confirm clean canonical names
- [ ] Create a recipe manually — descriptor field visible in form, saves correctly
- [ ] Recipe show page — ingredient lines read "quantity unit name, descriptor"
- [ ] Click an ingredient name link — filters by canonical name (e.g. "tomatoes"), not "crushed tomatoes"
- [ ] Create a magic recipe via AI — descriptor populated separately from name