### PR TITLE
Add recipe placeholder image

### DIFF
--- a/app/assets/images/recipe_placeholder.svg
+++ b/app/assets/images/recipe_placeholder.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <!-- Background: ~30% lighter than original cream (#fdf6ee mixed 30% toward white) -->
+  <rect width="400" height="300" fill="#fef9f3"/>
+
+  <!-- Subtle plate shadow -->
+  <ellipse cx="200" cy="180" rx="112" ry="13" fill="#c9ad94" opacity="0.2"/>
+
+  <!-- Plate -->
+  <circle cx="200" cy="150" r="112" fill="#faf3ea" stroke="#e4d0ba" stroke-width="2.5"/>
+
+  <!-- Plate inner decorative ring -->
+  <circle cx="200" cy="150" r="89" fill="none" stroke="#ecdcca" stroke-width="1.5"/>
+
+  <!--
+    Fork: translate to (111,158), rotate -14° for visual interest.
+    Local coords: 0,0 at centre of fork.
+    Tines: four rects, 3.5px wide, 2.5px gaps — proportioned like a table fork.
+    Shoulder: filled path that widens as tines merge into the shank.
+    Handle: rounded rect below.
+  -->
+  <g transform="translate(111,158) rotate(-14)" opacity="0.42" fill="#8b7355">
+    <!-- Tines (top to bottom: y=-47 to y=-12, 50% shorter than original 70px) -->
+    <rect x="-11"  y="-47" width="3.5" height="35" rx="1.8"/>
+    <rect x="-5"   y="-47" width="3.5" height="35" rx="1.8"/>
+    <rect x="1.5"  y="-47" width="3.5" height="35" rx="1.8"/>
+    <rect x="7.5"  y="-47" width="3.5" height="35" rx="1.8"/>
+    <!-- Shoulder: tines converge into the wider shank -->
+    <path d="M-12,-13 Q-13,0 -7,8 L7,8 Q13,0 14,-13 Z"/>
+    <!-- Handle -->
+    <rect x="-6.5" y="8" width="13" height="86" rx="6.5"/>
+  </g>
+
+  <!--
+    Knife: translate to (289,175), rotate +10°.
+    Blade cutting edge faces LEFT (toward plate interior).
+    Left side of blade bows out — this is the cutting/sharpened edge.
+    Right side is the spine (gently curved, thicker back).
+    Tip sits at upper-centre, where spine and edge meet.
+  -->
+  <g transform="translate(289,175) rotate(10)" opacity="0.38" fill="#8b7355">
+    <!-- Handle -->
+    <rect x="-5.5" y="22" width="11" height="82" rx="5.5"/>
+    <!-- Bolster (slightly wider, separates handle from blade) -->
+    <rect x="-7"   y="11" width="14" height="13" rx="2"/>
+    <!-- Blade: cutting edge on LEFT bows toward plate; spine on RIGHT is more upright -->
+    <path d="M-5.5,11 C-9,-5 -9,-45 1,-74 C2,-72 6,-45 6,11 Z"/>
+  </g>
+</svg>

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -3,7 +3,7 @@
     <%= render 'homepage_image', image: recipe.featured_image %>
   <% else %>
     <div class="image not_featured">
-      <%= link_to(image_tag('no_photo.png', class: 'w-full aspect-4/3 object-cover'), url_to_recipe(recipe)) %>
+      <%= link_to(image_tag('recipe_placeholder.svg', class: 'w-full aspect-4/3 object-cover'), url_to_recipe(recipe)) %>
     </div>
   <% end %>
   <h2 class="text-center text-sm px-3 py-3"><%= link_to(recipe.name, url_to_recipe(recipe), class: 'text-ink no-underline hover:text-terra hover:underline') %></h2>

--- a/app/views/recipes/_show_content.html.erb
+++ b/app/views/recipes/_show_content.html.erb
@@ -53,7 +53,11 @@
   </div>
 
   <div class="images col-span-full mt-4 grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4" id="image_list">
-    <%= render recipe.images.order('id') %>
+    <% if recipe.images.none? %>
+      <%= image_tag 'recipe_placeholder.svg', class: 'w-full rounded-lg object-cover aspect-4/3', alt: '' %>
+    <% else %>
+      <%= render recipe.images.order('id') %>
+    <% end %>
   </div>
 
 </article>


### PR DESCRIPTION
## Summary

- Adds `recipe_placeholder.svg`: a minimal plate-with-fork-and-knife illustration drawn in the site's ink-muted palette on a cream background
- Shows the placeholder on recipe index cards when no featured image is present (replacing the old generic `no_photo.png`)
- Shows the placeholder on the recipe show page when no images are attached at all

## Test plan

- [ ] CI passes
- [ ] Recipe index: cards without photos show the new placeholder
- [ ] Recipe show: recipes without images show the placeholder in the images section
- [ ] Recipe show: recipes with images are unaffected