### PR TITLE
Remove placeholder image from recipe show page

### DIFF
--- a/app/views/recipes/_show_content.html.erb
+++ b/app/views/recipes/_show_content.html.erb
@@ -53,11 +53,7 @@
   </div>
 
   <div class="images col-span-full mt-4 grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4" id="image_list">
-    <% if recipe.images.none? %>
-      <%= image_tag 'recipe_placeholder.svg', class: 'w-full rounded-lg object-cover aspect-4/3', alt: '' %>
-    <% else %>
-      <%= render recipe.images.order('id') %>
-    <% end %>
+    <%= render recipe.images.order('id') %>
   </div>
 
 </article>


### PR DESCRIPTION
Removes the placeholder SVG that was shown on recipe#show when no images are attached. The placeholder remains on index cards.