### PR TITLE
Add AI run tracking and observability

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -180,10 +180,12 @@ Lint/UselessAssignment:
 Metrics/AbcSize:
   Max: 29
 
-# Offense count: 1
+# Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 103
+  Exclude:
+    - 'app/services/recipe_text_extractor.rb'
 
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -242,6 +244,7 @@ RSpec/ContextWording:
     - 'spec/models/recipe_ingredient_spec.rb'
     - 'spec/models/recipe_spec.rb'
     - 'spec/models/user_spec.rb'
+    - 'spec/services/recipe_ai_extractor_spec.rb'
     - 'spec/support/shared_examples/autcomplete_controllers.rb'
 
 # Offense count: 9
@@ -335,6 +338,7 @@ RSpec/MultipleExpectations:
     - 'spec/features/user_filters_recipes_spec.rb'
     - 'spec/features/user_manages_recipes_spec.rb'
     - 'spec/services/recipe_ai_applier_spec.rb'
+    - 'spec/services/recipe_ai_extractor_spec.rb'
 
 # Offense count: 3
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
@@ -387,6 +391,7 @@ Rails/HasManyOrHasOneDependent:
 # Offense count: 7
 Rails/I18nLocaleTexts:
   Exclude:
+    - 'app/controllers/admin/ai_classifier_runs_controller.rb'
     - 'app/controllers/admin/base_controller.rb'
     - 'app/controllers/admin/magic_recipes_controller.rb'
     - 'app/controllers/admin/recipes_controller.rb'

--- a/.sample.env
+++ b/.sample.env
@@ -10,6 +10,11 @@
 
 # ANTHROPIC_API_KEY=
 
+# AI adapter: "anthropic" (default) or "ollama"
+# RECIPE_AI_ADAPTER=ollama
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_MODEL=llama3.2
+
 # S3_BUCKET_NAME=
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=

--- a/.sample.env
+++ b/.sample.env
@@ -9,11 +9,7 @@
 # GOOGLE_TRACKING_ID=
 
 # ANTHROPIC_API_KEY=
-
-# AI adapter: "anthropic" (default) or "ollama"
-# RECIPE_AI_ADAPTER=ollama
-# OLLAMA_URL=http://localhost:11434
-# OLLAMA_MODEL=llama3.2
+# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 
 # S3_BUCKET_NAME=
 # AWS_ACCESS_KEY_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Development uses `dotenv-rails` with a `.env` file (see `.sample.env` for requir
 |---|---|---|
 | `SECRET_KEY_BASE` | All | Rails secret key (generate with `bundle exec rake secret`) |
 | `ANTHROPIC_API_KEY` | All | AI recipe import |
+| `ANTHROPIC_MODEL` | All | Claude model for extraction (default: `claude-haiku-4-5-20251001`) |
 | `DEFAULT_SENDER` | All | Devise mailer from address |
 | `APP_NAME` | All | Display name in layout (default: "Recipes") |
 | `HOST` | Dev/Prod | Mailer URL host (default: `localhost:3000`) |

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'will_paginate'
 gem 'redcarpet'
 gem 'aws-sdk-s3', require: false
 gem 'solid_queue'
-gem 'anthropic'
+gem 'ruby_llm'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,9 +85,6 @@ GEM
       activerecord (>= 4.2)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
-    anthropic (1.20.0)
-      cgi
-      connection_pool
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1212.0)
@@ -133,7 +130,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.5.1)
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
@@ -168,11 +164,22 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -226,7 +233,10 @@ GEM
     mini_mime (1.1.5)
     minitest (6.0.1)
       prism (~> 1.5)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.2)
       date
       net-protocol
@@ -395,6 +405,17 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    ruby_llm (1.12.1)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 2.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 2.0)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.3.0)
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.40.0)
@@ -475,7 +496,6 @@ DEPENDENCIES
   active_storage_validations
   acts-as-taggable-on (~> 13.0)
   acts_as_list
-  anthropic
   aws-sdk-s3
   base64
   better_errors
@@ -510,6 +530,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby_llm
   selenium-webdriver
   shoulda-matchers (~> 5.0)
   simple_form
@@ -521,7 +542,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 4.0.1p0
+  ruby 4.0.1p0
 
 BUNDLED WITH
-   4.0.6
+  4.0.6

--- a/app/controllers/admin/ai_classifier_runs_controller.rb
+++ b/app/controllers/admin/ai_classifier_runs_controller.rb
@@ -1,0 +1,68 @@
+module Admin
+  class AiClassifierRunsController < BaseController
+    before_action :find_run, only: %i[show rerun]
+
+    def index
+      base = AiClassifierRun.all
+      base = base.by_success(params[:success]) if params[:success].present?
+      base = base.for_recipe(params[:recipe_id]) if params[:recipe_id].present?
+
+      per_page = 10
+      page     = (params[:page] || 1).to_i
+      total    = base.distinct.count(:recipe_id)
+
+      @recipe_ids        = paginated_recipe_ids(base, page, per_page)
+      @runs_by_recipe_id = grouped_runs(base, @recipe_ids)
+      @pagination        = WillPaginate::Collection.new(page, per_page, total)
+
+      assign_stats
+      assign_filtered_recipe
+    end
+
+    def show; end
+
+    def rerun
+      if @run.recipe.present?
+        MagicRecipeJob.perform_later(@run.recipe.id)
+        redirect_to admin_ai_classifier_run_path(@run), notice: 'Recipe re-enqueued for processing.'
+      else
+        redirect_to admin_ai_classifier_run_path(@run), alert: 'No associated recipe to rerun.'
+      end
+    end
+
+    private
+
+    def paginated_recipe_ids(base, page, per_page)
+      query = base.group(:recipe_id).order(Arel.sql('MAX(started_at) DESC NULLS LAST'))
+      query = query.limit(per_page).offset((page - 1) * per_page)
+      query.pluck(:recipe_id)
+    end
+
+    def grouped_runs(base, recipe_ids)
+      runs = base.where(recipe_id: recipe_ids).includes(:recipe).order(started_at: :desc)
+      runs.group_by(&:recipe_id)
+    end
+
+    def assign_stats
+      @total_count   = AiClassifierRun.count
+      @success_count = AiClassifierRun.successful.count
+      @failure_count = AiClassifierRun.failed.count
+      @avg_duration  = compute_avg_duration
+    end
+
+    def assign_filtered_recipe
+      @filtered_recipe = Recipe.find(params[:recipe_id]) if params[:recipe_id].present?
+    end
+
+    def find_run
+      @run = AiClassifierRun.includes(:recipe).find(params[:id])
+    end
+
+    def compute_avg_duration
+      AiClassifierRun
+        .where.not(started_at: nil).where.not(completed_at: nil)
+        .average('EXTRACT(EPOCH FROM (completed_at - started_at)) * 1000')
+        &.round
+    end
+  end
+end

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -7,6 +7,8 @@ module Admin
       @recipes = Recipe.includes(:user, :images).recent
       @recipes = @recipes.by_status(params[:status]) if params[:status].present?
       @recipes = @recipes.paginate(page: params[:page], per_page: 20)
+      recipe_ids  = @recipes.map(&:id)
+      @run_counts = AiClassifierRun.where(recipe_id: recipe_ids).group(:recipe_id).count
     end
 
     def publish

--- a/app/jobs/magic_recipe_job.rb
+++ b/app/jobs/magic_recipe_job.rb
@@ -6,15 +6,15 @@ class MagicRecipeJob < ApplicationJob
   def perform(recipe_id)
     recipe = Recipe.find(recipe_id)
     recipe.strict_loading!(false)
-    recipe.update!(status: 'processing', ai_error: nil)
+    recipe.update!(status: 'processing')
 
     text = extract_text(recipe)
-    data = RecipeAiExtractor.extract(text)
+    data = RecipeAiExtractor.extract(text, recipe: recipe)
     RecipeAiApplier.apply(recipe, data)
 
     recipe.update!(status: 'review')
-  rescue StandardError => e
-    recipe&.update_columns(status: 'processing_failed', ai_error: e.message) # rubocop:disable Rails/SkipsModelValidations
+  rescue StandardError
+    recipe&.update_columns(status: 'processing_failed') # rubocop:disable Rails/SkipsModelValidations
     raise
   end
 
@@ -22,7 +22,7 @@ class MagicRecipeJob < ApplicationJob
 
   def extract_text(recipe)
     if recipe.source_url.present?
-      RecipeTextExtractor.from_url(recipe.source_url)
+      RecipeTextExtractor.from_url(recipe.source_url, recipe: recipe)
     else
       recipe.source_text
     end

--- a/app/models/ai_classifier_run.rb
+++ b/app/models/ai_classifier_run.rb
@@ -1,0 +1,31 @@
+class AiClassifierRun < ApplicationRecord
+  ADAPTERS        = %w[anthropic].freeze
+  SERVICE_CLASSES = %w[RecipeTextExtractor RecipeAiExtractor RecipeAiApplier].freeze
+
+  belongs_to :recipe, optional: true
+
+  validates :service_class, presence: true, inclusion: { in: SERVICE_CLASSES }
+  validates :adapter,       inclusion: { in: ADAPTERS }, allow_nil: true
+  validates :ai_model,      presence: true, if: -> { adapter.present? }
+  validates :success,       inclusion: { in: [true, false] }
+
+  scope :recent,      -> { order(created_at: :desc) }
+  scope :successful,  -> { where(success: true) }
+  scope :failed,      -> { where(success: false) }
+  scope :by_success,  ->(val) { where(success: val) if val.in?(%w[true false]) }
+  scope :for_recipe,  ->(id) { where(recipe_id: id) }
+
+  def in_progress?
+    completed_at.nil?
+  end
+
+  def duration_ms
+    return nil unless started_at && completed_at
+
+    ((completed_at - started_at) * 1000).round
+  end
+
+  def recipe_name
+    recipe&.name || '(recipe deleted)'
+  end
+end

--- a/app/services/recipe_ai_applier.rb
+++ b/app/services/recipe_ai_applier.rb
@@ -9,21 +9,35 @@ class RecipeAiApplier
   end
 
   def apply
-    @recipe.strict_loading!(false)
-    @recipe.assign_attributes(
-      name: @data['name'] || @recipe.name,
-      description: @data['description'],
-      directions: @data['directions'],
-      preparation_time: @data['preparation_time'],
-      cooking_time: @data['cooking_time'],
-      servings: @data['servings'],
-      serving_units: @data['serving_units']
+    run = AiClassifierRun.create!(
+      service_class: 'RecipeAiApplier',
+      recipe: @recipe,
+      user_prompt: @data.to_json,
+      started_at: Time.current,
+      success: false
     )
 
-    apply_ingredients
-    apply_tags
+    begin
+      @recipe.strict_loading!(false)
+      @recipe.assign_attributes(
+        name: @data['name'] || @recipe.name,
+        description: @data['description'],
+        directions: @data['directions'],
+        preparation_time: @data['preparation_time'],
+        cooking_time: @data['cooking_time'],
+        servings: @data['servings'],
+        serving_units: @data['serving_units']
+      )
 
-    @recipe.save!
+      apply_ingredients
+      apply_tags
+
+      @recipe.save!
+      run.update!(success: true, completed_at: Time.current)
+    rescue StandardError => e
+      run.update!(success: false, error_class: e.class.name, error_message: e.message, completed_at: Time.current)
+      raise
+    end
   end
 
   private

--- a/app/services/recipe_ai_extractor.rb
+++ b/app/services/recipe_ai_extractor.rb
@@ -117,7 +117,7 @@ class RecipeAiExtractor
       req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
       req.body = body
 
-      res = Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+      res = Net::HTTP.start(uri.hostname, uri.port, read_timeout: 600, open_timeout: 60) { |http| http.request(req) }
       raise "Ollama request failed (#{res.code}): #{res.body}" unless res.is_a?(Net::HTTPSuccess)
 
       JSON.parse(res.body).dig('message', 'content')

--- a/app/services/recipe_ai_extractor.rb
+++ b/app/services/recipe_ai_extractor.rb
@@ -24,6 +24,7 @@ class RecipeAiExtractor
     Ingredients:
     - Names should be the plain canonical ingredient only, lowercase (e.g. "onion", "garlic", "tomato"). No prep verbs, no quality adjectives, strip specific brand names
     - Put any preparation method or quality descriptor in the separate `descriptor` field, lowercase (e.g. "diced", "minced", "ripe", "fresh", "crushed"). Omit the field (or use null) if there is no descriptor
+    - When the recipe offers a choice between two ingredients (e.g., "1 lb beef or turkey", "chicken or tofu"), list the primary (first-mentioned) option as the ingredient name. Encode the alternative in the descriptor field using the format "or [alternative]" (e.g., name: "beef", descriptor: "or turkey"). Do not create a separate ingredient entry for the alternative.
     - Quantity should be a string that can include fractions like "1/2". Use "to taste" when no specific amount is given
     - Unit should be a standard measurement (cup, tbsp, tsp, oz, lb, etc.) or empty string when not applicable (e.g. "2" "large" "eggs")
     - Every ingredient in the list MUST be referenced in the directions. If the source text mentions an ingredient only in the directions but not in the ingredient list, add it to the ingredients list
@@ -41,7 +42,8 @@ class RecipeAiExtractor
 
     Directions:
     - Clear numbered steps — ONLY actionable cooking instructions
-    - Strip out completely: life stories, personal anecdotes, blog filler, ads, "notes" sections, variation suggestions ("you could also use..."), storage/reheating tips, and serving suggestions
+    - Strip out completely: life stories, personal anecdotes, blog filler, ads, "notes" sections, after-the-fact variation suggestions ("you could also substitute...", "feel free to swap..."), storage/reheating tips, and serving suggestions — but preserve "X or Y" choices that are stated as part of the original recipe
+    - When a step uses an ingredient that has an alternative (where the recipe says "X or Y"), name both options explicitly in that step (e.g., "Brown the beef (or turkey) over medium heat" rather than "Brown the meat")
     - Reference ingredients by the same name used in the ingredients list for consistency
     - When sections exist, the directions should reference which component is being prepared (e.g. "For the crust, combine...")
     - Combine trivially small sub-steps into single steps where it makes sense

--- a/app/services/recipe_ai_extractor.rb
+++ b/app/services/recipe_ai_extractor.rb
@@ -53,30 +53,45 @@ class RecipeAiExtractor
     Return ONLY valid JSON, no JSON markdown code fences, no explanation.
   PROMPT
 
-  def self.extract(text)
-    new(text).extract
+  def self.extract(text, recipe: nil)
+    new(text, recipe: recipe).extract
   end
 
-  def initialize(text)
-    @text = text
+  def initialize(text, recipe: nil)
+    @text   = text
+    @recipe = recipe
   end
 
   def extract
-    json_text = adapter.complete(SYSTEM_PROMPT, user_message)
-    JSON.parse(normalize_json(json_text))
+    run = AiClassifierRun.create!(
+      service_class: 'RecipeAiExtractor',
+      recipe: @recipe,
+      adapter: current_adapter.adapter_name,
+      ai_model: current_adapter.ai_model,
+      system_prompt: SYSTEM_PROMPT,
+      user_prompt: user_message,
+      started_at: Time.current,
+      success: false
+    )
+
+    begin
+      raw = current_adapter.complete(SYSTEM_PROMPT, user_message)
+      run.update!(raw_response: raw, success: true, completed_at: Time.current)
+      JSON.parse(normalize_json(raw))
+    rescue StandardError => e
+      run.update!(success: false, error_class: e.class.name, error_message: e.message, completed_at: Time.current)
+      raise
+    end
   end
 
   private
 
   def user_message
-    "Extract the recipe from this text:\n\n#{@text}"
+    @user_message ||= "Extract the recipe from this text:\n\n#{@text}"
   end
 
-  def adapter
-    case ENV.fetch('RECIPE_AI_ADAPTER', 'anthropic')
-    when 'ollama' then OllamaAdapter.new
-    else               AnthropicAdapter.new
-    end
+  def current_adapter
+    @current_adapter ||= AnthropicAdapter.new
   end
 
   def normalize_json(text)
@@ -88,49 +103,15 @@ class RecipeAiExtractor
   # ---------------------------------------------------------------------------
 
   class AnthropicAdapter
+    DEFAULT_MODEL = 'claude-haiku-4-5-20251001'.freeze
+
+    def adapter_name = 'anthropic'
+    def ai_model     = ENV.fetch('ANTHROPIC_MODEL', DEFAULT_MODEL)
+
     def complete(system_prompt, user_message)
-      client = Anthropic::Client.new(api_key: ENV.fetch('ANTHROPIC_API_KEY'))
-      response = client.messages.create(
-        model: 'claude-sonnet-4-5-20250929',
-        max_tokens: 4096,
-        system: system_prompt,
-        messages: [{ role: 'user', content: user_message }]
-      )
-      response.content.first.text
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-
-  class OllamaAdapter
-    def complete(system_prompt, user_message)
-      uri = URI("#{base_url}/api/chat")
-      body = {
-        model: model,
-        stream: false,
-        messages: [
-          { role: 'system', content: system_prompt },
-          { role: 'user',   content: user_message }
-        ]
-      }.to_json
-
-      req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
-      req.body = body
-
-      res = Net::HTTP.start(uri.hostname, uri.port, read_timeout: 600, open_timeout: 60) { |http| http.request(req) }
-      raise "Ollama request failed (#{res.code}): #{res.body}" unless res.is_a?(Net::HTTPSuccess)
-
-      JSON.parse(res.body).dig('message', 'content')
-    end
-
-    private
-
-    def base_url
-      ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
-    end
-
-    def model
-      ENV.fetch('OLLAMA_MODEL', 'llama3.2')
+      chat = RubyLLM.chat(model: ai_model)
+      chat.with_instructions(system_prompt)
+      chat.ask(user_message).content
     end
   end
 end

--- a/app/services/recipe_text_extractor.rb
+++ b/app/services/recipe_text_extractor.rb
@@ -10,15 +10,37 @@ class RecipeTextExtractor
                     'prepTime' => 'Prep Time', 'cookTime' => 'Cook Time',
                     'recipeYield' => 'Yield' }.freeze
 
-  def self.from_url(url)
-    new(url).extract
+  def self.from_url(url, recipe: nil)
+    new(url, recipe: recipe).extract
   end
 
-  def initialize(url)
-    @url = url
+  def initialize(url, recipe: nil)
+    @url    = url
+    @recipe = recipe
   end
 
   def extract
+    run = AiClassifierRun.create!(
+      service_class: 'RecipeTextExtractor',
+      recipe: @recipe,
+      user_prompt: @url,
+      started_at: Time.current,
+      success: false
+    )
+
+    begin
+      result = fetch_and_parse
+      run.update!(raw_response: result, success: true, completed_at: Time.current)
+      result
+    rescue StandardError => e
+      run.update!(success: false, error_class: e.class.name, error_message: e.message, completed_at: Time.current)
+      raise
+    end
+  end
+
+  private
+
+  def fetch_and_parse
     uri = URI.parse(@url)
     response = Net::HTTP.get_response(uri)
 
@@ -33,8 +55,6 @@ class RecipeTextExtractor
     end
     clean_text(text.to_s)
   end
-
-  private
 
   def strip_non_content!(doc)
     doc.css('script, style, nav, footer, header, iframe, .ad, .ads, .advertisement, [role="navigation"]').remove

--- a/app/views/admin/ai_classifier_runs/index.html.erb
+++ b/app/views/admin/ai_classifier_runs/index.html.erb
@@ -1,0 +1,106 @@
+<div class="max-w-6xl mx-auto p-4 md:p-6">
+  <div class="flex items-center justify-between mb-6">
+    <% if @filtered_recipe %>
+      <div>
+        <h1 class="text-3xl text-ink">AI Runs: <%= @filtered_recipe.name %></h1>
+        <%= link_to '← All recipes', admin_ai_classifier_runs_path, class: 'text-terra hover:underline no-underline text-sm' %>
+      </div>
+    <% else %>
+      <h1 class="text-3xl text-ink">Admin: AI Classifier Runs</h1>
+    <% end %>
+  </div>
+
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+    <div class="bg-white rounded-xl shadow-sm border border-cream-dark px-5 py-4 text-center">
+      <div class="text-2xl font-bold text-ink"><%= @total_count %></div>
+      <div class="text-sm text-ink-light mt-1">Total Runs</div>
+    </div>
+    <div class="bg-white rounded-xl shadow-sm border border-cream-dark px-5 py-4 text-center">
+      <div class="text-2xl font-bold text-green-700"><%= @success_count %></div>
+      <div class="text-sm text-ink-light mt-1">Successes</div>
+    </div>
+    <div class="bg-white rounded-xl shadow-sm border border-cream-dark px-5 py-4 text-center">
+      <div class="text-2xl font-bold text-red-700"><%= @failure_count %></div>
+      <div class="text-sm text-ink-light mt-1">Failures</div>
+    </div>
+    <div class="bg-white rounded-xl shadow-sm border border-cream-dark px-5 py-4 text-center">
+      <div class="text-2xl font-bold text-ink"><%= @avg_duration ? "#{(@avg_duration / 1000.0).round(1)}s" : '—' %></div>
+      <div class="text-sm text-ink-light mt-1">Avg Duration</div>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-x-3 overflow-x-auto bg-white rounded-xl px-5 py-3 shadow-sm border border-cream-dark text-sm mb-6">
+    <% all_active = params[:success].blank? %>
+    <%= link_to "All (#{@total_count})", admin_ai_classifier_runs_path(recipe_id: params[:recipe_id]),
+        class: ['font-medium no-underline px-2 py-0.5 rounded-md',
+                all_active ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline'].join(' ') %>
+    <%= link_to "Success (#{@success_count})", admin_ai_classifier_runs_path(success: 'true', recipe_id: params[:recipe_id]),
+        class: ['font-medium no-underline px-2 py-0.5 rounded-md',
+                params[:success] == 'true' ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline'].join(' ') %>
+    <%= link_to "Failed (#{@failure_count})", admin_ai_classifier_runs_path(success: 'false', recipe_id: params[:recipe_id]),
+        class: ['font-medium no-underline px-2 py-0.5 rounded-md',
+                params[:success] == 'false' ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline'].join(' ') %>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm overflow-hidden divide-y divide-gray-100">
+    <% if @recipe_ids.empty? %>
+      <div class="px-4 py-8 text-center text-ink-light">No runs yet.</div>
+    <% end %>
+
+    <% @recipe_ids.each do |recipe_id| %>
+      <% runs = @runs_by_recipe_id[recipe_id] || [] %>
+      <% recipe = runs.first&.recipe %>
+      <% last_run = runs.max_by(&:started_at) %>
+
+      <%# Recipe header row %>
+      <div class="flex items-center justify-between px-4 py-3 bg-gray-50">
+        <div class="flex items-center gap-3">
+          <% if recipe.present? %>
+            <%= link_to recipe.name, recipe_path(recipe), class: 'font-semibold text-terra hover:underline no-underline text-sm' %>
+          <% else %>
+            <em class="text-ink-light text-sm">(recipe deleted)</em>
+          <% end %>
+          <% if last_run&.started_at %>
+            <span class="text-xs text-ink-light">last run <%= last_run.started_at.in_time_zone('America/New_York').strftime('%-d %b %Y %H:%M %Z') %></span>
+          <% end %>
+        </div>
+        <div class="flex items-center gap-3">
+          <% if recipe.present? %>
+            <%= button_to 'Rerun', rerun_admin_ai_classifier_run_path(last_run), method: :post,
+                class: 'text-orange-700 hover:underline bg-transparent border-0 cursor-pointer p-0 text-xs' %>
+          <% end %>
+        </div>
+      </div>
+
+      <%# Per-run rows %>
+      <% runs.each do |run| %>
+        <div class="flex items-center gap-4 pl-8 pr-4 py-2 text-xs border-t border-gray-100 hover:bg-gray-50">
+          <span class="inline-block px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 font-medium shrink-0"><%= run.service_class %></span>
+
+          <% if run.in_progress? %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full font-medium bg-yellow-100 text-yellow-800">running</span>
+          <% elsif run.success? %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800">success</span>
+          <% else %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full font-medium bg-red-100 text-red-800">failed</span>
+          <% end %>
+
+          <span class="text-ink-light"><%= run.duration_ms ? "#{(run.duration_ms / 1000.0).round(1)}s" : '—' %></span>
+
+          <% if run.adapter.present? %>
+            <span class="text-ink-light"><%= run.adapter %> / <span class="font-mono"><%= run.ai_model %></span></span>
+          <% end %>
+
+          <span class="text-ink-light ml-auto"><%= run.started_at ? run.started_at.in_time_zone('America/New_York').strftime('%-d %b %Y %H:%M %Z') : '—' %></span>
+
+          <%= link_to 'Show', admin_ai_classifier_run_path(run), class: 'text-terra hover:underline ml-2 shrink-0' %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="mt-4">
+    <%= will_paginate @pagination %>
+  </div>
+</div>
+<% content_for(:page_title, 'Admin: AI Classifier Runs') %>

--- a/app/views/admin/ai_classifier_runs/show.html.erb
+++ b/app/views/admin/ai_classifier_runs/show.html.erb
@@ -1,0 +1,103 @@
+<div class="max-w-4xl mx-auto p-4 md:p-6">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-3xl text-ink">AI Classifier Run #<%= @run.id %></h1>
+    <%= link_to '← Back to Runs', admin_ai_classifier_runs_path, class: 'text-terra hover:underline no-underline text-sm' %>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-cream-dark p-6 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+      <div>
+        <span class="font-semibold text-ink">Service:</span>
+        <span class="inline-block px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 font-medium text-xs ml-1"><%= @run.service_class %></span>
+      </div>
+      <div>
+        <span class="font-semibold text-ink">Recipe:</span>
+        <% if @run.recipe.present? %>
+          <%= link_to @run.recipe.name, recipe_path(@run.recipe), class: 'text-terra hover:underline ml-1' %>
+        <% else %>
+          <em class="text-ink-light ml-1">(recipe deleted)</em>
+        <% end %>
+      </div>
+      <div>
+        <span class="font-semibold text-ink">Status:</span>
+        <span class="ml-1">
+          <% if @run.in_progress? %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">running</span>
+          <% elsif @run.success? %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">success</span>
+          <% else %>
+            <span class="inline-block px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">failed</span>
+          <% end %>
+        </span>
+      </div>
+      <% if @run.adapter.present? %>
+        <div>
+          <span class="font-semibold text-ink">Adapter:</span>
+          <span class="text-ink-light ml-1"><%= @run.adapter %></span>
+        </div>
+        <div>
+          <span class="font-semibold text-ink">Model:</span>
+          <span class="text-ink-light font-mono text-xs ml-1"><%= @run.ai_model %></span>
+        </div>
+      <% end %>
+      <div>
+        <span class="font-semibold text-ink">Started At:</span>
+        <span class="text-ink-light ml-1"><%= @run.started_at ? @run.started_at.in_time_zone('America/New_York').strftime('%-d %b %Y %H:%M %Z') : '—' %></span>
+      </div>
+      <div>
+        <span class="font-semibold text-ink">Duration:</span>
+        <span class="text-ink-light ml-1"><%= @run.duration_ms ? "#{(@run.duration_ms / 1000.0).round(1)}s" : '—' %></span>
+      </div>
+    </div>
+
+    <% if @run.recipe.present? %>
+      <div class="mt-5 pt-5 border-t border-cream-dark">
+        <%= button_to 'Rerun', rerun_admin_ai_classifier_run_path(@run), method: :post,
+            class: 'inline-flex items-center bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-orange-700 transition-colors' %>
+      </div>
+    <% end %>
+  </div>
+
+  <% unless @run.success? || @run.in_progress? %>
+    <div class="bg-red-50 border border-red-200 rounded-xl p-5 mb-6">
+      <h2 class="text-base font-semibold text-red-800 mb-2">Error Details</h2>
+      <div class="text-sm text-red-700 space-y-1">
+        <div><span class="font-medium">Class:</span> <%= @run.error_class %></div>
+        <div><span class="font-medium">Message:</span> <%= @run.error_message %></div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="space-y-4">
+    <details class="bg-white rounded-xl shadow-sm border border-cream-dark overflow-hidden">
+      <summary class="px-5 py-3 font-semibold text-ink cursor-pointer hover:bg-gray-50 text-sm">System Prompt</summary>
+      <div class="border-t border-cream-dark p-4">
+        <pre class="text-xs font-mono whitespace-pre-wrap text-ink-light"><%= @run.system_prompt.presence || '(none)' %></pre>
+      </div>
+    </details>
+
+    <details class="bg-white rounded-xl shadow-sm border border-cream-dark overflow-hidden">
+      <summary class="px-5 py-3 font-semibold text-ink cursor-pointer hover:bg-gray-50 text-sm">User Prompt</summary>
+      <div class="border-t border-cream-dark p-4">
+        <pre class="text-xs font-mono whitespace-pre-wrap text-ink-light"><%= @run.user_prompt %></pre>
+      </div>
+    </details>
+
+    <details class="bg-white rounded-xl shadow-sm border border-cream-dark overflow-hidden">
+      <summary class="px-5 py-3 font-semibold text-ink cursor-pointer hover:bg-gray-50 text-sm">Raw Response</summary>
+      <div class="border-t border-cream-dark p-4">
+        <pre class="text-xs font-mono whitespace-pre-wrap text-ink-light"><%= @run.raw_response.presence || '(none)' %></pre>
+      </div>
+    </details>
+  </div>
+
+  <% if @run.recipe_id.present? %>
+    <div class="mt-6 bg-white rounded-xl shadow-sm border border-cream-dark p-5">
+      <h2 class="text-sm font-semibold text-ink mb-2">Other runs for <%= @run.recipe_name %></h2>
+      <%= link_to "View all runs for this recipe →",
+          admin_ai_classifier_runs_path(recipe_id: @run.recipe_id),
+          class: 'text-terra hover:underline text-sm' %>
+    </div>
+  <% end %>
+</div>
+<% content_for(:page_title, "AI Classifier Run ##{@run.id}") %>

--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -14,10 +14,12 @@
                   active ? 'text-terra bg-terra-faint' : 'text-ink-light hover:text-terra hover:underline',
                   count.zero? && !active ? 'opacity-50' : nil].compact.join(' ') %>
     <% end %>
-    <span class="text-cream-dark">|</span>
-    <%= link_to new_admin_magic_recipe_path, class: 'inline-flex items-center gap-1.5 bg-terra-dark text-white px-3 py-1 rounded-lg no-underline hover:bg-terra font-medium transition-colors' do %>
-      <span class="text-[1.5em] leading-none">🪄</span> New Magic Recipe
-    <% end %>
+    <div class="ml-auto flex items-center gap-x-3">
+      <%= link_to 'AI Runs', admin_ai_classifier_runs_path, class: 'text-ink-light hover:text-terra no-underline font-medium text-sm' %>
+      <%= link_to new_admin_magic_recipe_path, class: 'inline-flex items-center gap-1.5 bg-terra-dark text-white px-3 py-1 rounded-lg no-underline hover:bg-terra font-medium transition-colors' do %>
+        <span class="text-[1.5em] leading-none">🪄</span> New Magic Recipe
+      <% end %>
+    </div>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm overflow-hidden">
@@ -27,6 +29,7 @@
           <th class="px-4 py-3 font-semibold text-ink">Name</th>
           <th class="px-4 py-3 font-semibold text-ink">Author</th>
           <th class="px-4 py-3 font-semibold text-ink">Status</th>
+          <th class="px-4 py-3 font-semibold text-ink">Runs</th>
           <th class="px-4 py-3 font-semibold text-ink">Created</th>
           <th class="px-4 py-3 font-semibold text-ink">Actions</th>
         </tr>
@@ -42,6 +45,11 @@
             </td>
             <td class="px-4 py-3 text-ink-light"><%= recipe.user_email %></td>
             <td class="px-4 py-3"><%= render 'status_badge', status: recipe.status %></td>
+            <td class="px-4 py-3 text-ink-light">
+              <%= link_to @run_counts[recipe.id] || 0,
+                  admin_ai_classifier_runs_path(recipe_id: recipe.id),
+                  class: 'text-terra hover:underline' %>
+            </td>
             <td class="px-4 py-3 text-ink-light"><%= l(recipe.created_at, format: :default) %></td>
             <td class="px-4 py-3 space-x-2">
               <% if recipe.publishable? %>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -1,12 +1,5 @@
 <%= simple_form_for @recipe, html: { class: 'w-full p-4 md:p-8 space-y-6' } do |f| %>
 
-  <% if @recipe.status != 'published' && @recipe.ai_error.present? %>
-    <div class="p-4 bg-red-50 border border-red-200 rounded-xl">
-      <p class="text-sm font-semibold text-red-700">AI Processing Error</p>
-      <p class="text-sm text-red-600 mt-1"><%= @recipe.ai_error %></p>
-    </div>
-  <% end %>
-
   <fieldset class="border border-cream-dark rounded-xl p-5 bg-white/50" id="recipe_metadata">
     <legend class="text-xl font-display px-3 py-1 bg-cream-dark rounded-md text-ink">
       <% if @recipe.persisted? %>
@@ -142,12 +135,6 @@
       <%= f.input :source_url %>
       <%= f.input :source_text, as: :text, input_html: { class: 'h-24' } %>
 
-      <% if @recipe.ai_error.present? %>
-        <div class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-          <p class="text-sm font-semibold text-red-700">AI Error</p>
-          <p class="text-sm text-red-600"><%= @recipe.ai_error %></p>
-        </div>
-      <% end %>
     </fieldset>
   <% end %>
 

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,4 @@
+RubyLLM.configure do |config|
+  config.anthropic_api_key = ENV.fetch('ANTHROPIC_API_KEY', nil)
+  config.request_timeout   = 600
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
       end
     end
     resources :magic_recipes, only: [:new, :create]
+    resources :ai_classifier_runs, only: [:index, :show] do
+      member { post :rerun }
+    end
   end
 
   resources :recipes, only: [:index, :new, :create, :show, :edit, :update] do

--- a/db/migrate/20260221185840_create_ai_classifier_runs.rb
+++ b/db/migrate/20260221185840_create_ai_classifier_runs.rb
@@ -1,0 +1,21 @@
+class CreateAiClassifierRuns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_classifier_runs do |t|
+      t.integer  :recipe_id
+      t.string   :adapter,     null: false
+      t.string   :ai_model,    null: false
+      t.text     :system_prompt
+      t.text     :user_prompt
+      t.text     :raw_response
+      t.boolean  :success,     null: false, default: false
+      t.string   :error_class
+      t.text     :error_message
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.timestamps
+    end
+    add_index :ai_classifier_runs, :recipe_id
+    add_index :ai_classifier_runs, :success
+    add_index :ai_classifier_runs, :created_at
+  end
+end

--- a/db/migrate/20260221185936_remove_ai_error_from_recipes.rb
+++ b/db/migrate/20260221185936_remove_ai_error_from_recipes.rb
@@ -1,0 +1,5 @@
+class RemoveAiErrorFromRecipes < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :recipes, :ai_error, :text
+  end
+end

--- a/db/migrate/20260221190000_add_service_class_to_ai_classifier_runs.rb
+++ b/db/migrate/20260221190000_add_service_class_to_ai_classifier_runs.rb
@@ -1,0 +1,15 @@
+class AddServiceClassToAiClassifierRuns < ActiveRecord::Migration[8.0]
+  def up
+    add_column :ai_classifier_runs, :service_class, :string
+    change_column_null :ai_classifier_runs, :adapter, true
+    change_column_null :ai_classifier_runs, :ai_model, true
+    execute "UPDATE ai_classifier_runs SET service_class = 'RecipeAiExtractor'"
+    change_column_null :ai_classifier_runs, :service_class, false
+  end
+
+  def down
+    remove_column :ai_classifier_runs, :service_class
+    change_column_null :ai_classifier_runs, :adapter, false
+    change_column_null :ai_classifier_runs, :ai_model, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_20_163302) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_21_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,26 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_20_163302) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "ai_classifier_runs", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.string "adapter"
+    t.string "ai_model"
+    t.text "system_prompt"
+    t.text "user_prompt"
+    t.text "raw_response"
+    t.boolean "success", default: false, null: false
+    t.string "error_class"
+    t.text "error_message"
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "service_class", null: false
+    t.index ["created_at"], name: "index_ai_classifier_runs_on_created_at"
+    t.index ["recipe_id"], name: "index_ai_classifier_runs_on_recipe_id"
+    t.index ["success"], name: "index_ai_classifier_runs_on_success"
   end
 
   create_table "images", force: :cascade do |t|
@@ -89,7 +109,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_20_163302) do
     t.string "description", limit: 2048
     t.string "source_url", limit: 2048
     t.text "source_text"
-    t.text "ai_error"
     t.string "status", default: "draft", null: false
     t.index ["status"], name: "index_recipes_on_status"
     t.index ["user_id"], name: "index_recipes_on_user_id"

--- a/spec/controllers/admin/ai_classifier_runs_controller_spec.rb
+++ b/spec/controllers/admin/ai_classifier_runs_controller_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Admin::AiClassifierRunsController do
+  describe 'non-admin access' do
+    context 'when guest' do
+      it 'redirects from index' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when regular user' do
+      before { sign_in_user build(:user, admin: false) }
+
+      it 'redirects from index' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'admin access' do
+    let(:admin) { build(:user, :admin) }
+
+    before { sign_in_user admin }
+
+    describe '#index' do
+      it 'is successful' do
+        get :index
+        expect(response).to be_successful
+      end
+
+      it 'assigns recipe_ids grouped by most recent run' do
+        recipe1 = create(:recipe)
+        recipe2 = create(:recipe)
+        create(:ai_classifier_run, :with_recipe, recipe: recipe1, started_at: 2.hours.ago)
+        create(:ai_classifier_run, :with_recipe, recipe: recipe2, started_at: 1.hour.ago)
+
+        get :index
+
+        expect(assigns(:recipe_ids)).to eq([recipe2.id, recipe1.id])
+      end
+
+      it 'assigns runs grouped by recipe_id' do
+        recipe = create(:recipe)
+        run = create(:ai_classifier_run, :with_recipe, recipe: recipe)
+
+        get :index
+
+        expect(assigns(:runs_by_recipe_id)).to have_key(recipe.id)
+        expect(assigns(:runs_by_recipe_id)[recipe.id]).to include(run)
+      end
+
+      it 'assigns pagination object' do
+        get :index
+        expect(assigns(:pagination)).to be_a(WillPaginate::Collection)
+      end
+
+      it 'filters by success param' do
+        recipe1 = create(:recipe)
+        recipe2 = create(:recipe)
+        create(:ai_classifier_run, :with_recipe, recipe: recipe1, success: true)
+        create(:ai_classifier_run, :with_recipe, :failed, recipe: recipe2)
+
+        get :index, params: { success: 'true' }
+
+        expect(assigns(:recipe_ids)).to include(recipe1.id)
+        expect(assigns(:recipe_ids)).not_to include(recipe2.id)
+      end
+
+      it 'filters by recipe_id param' do
+        recipe1 = create(:recipe)
+        recipe2 = create(:recipe)
+        create(:ai_classifier_run, :with_recipe, recipe: recipe1)
+        create(:ai_classifier_run, :with_recipe, recipe: recipe2)
+
+        get :index, params: { recipe_id: recipe1.id }
+
+        expect(assigns(:recipe_ids)).to contain_exactly(recipe1.id)
+        expect(assigns(:filtered_recipe)).to eq(recipe1)
+      end
+
+      it 'assigns stat counts' do
+        create(:ai_classifier_run, success: true)
+        create(:ai_classifier_run, :failed)
+
+        get :index
+
+        expect(assigns(:total_count)).to eq(2)
+        expect(assigns(:success_count)).to eq(1)
+        expect(assigns(:failure_count)).to eq(1)
+      end
+    end
+
+    describe '#show' do
+      it 'is successful and assigns the run' do
+        run = create(:ai_classifier_run)
+        get :show, params: { id: run.id }
+
+        expect(response).to be_successful
+        expect(assigns(:run)).to eq(run)
+      end
+    end
+
+    describe '#rerun' do
+      context 'when run has an associated recipe' do
+        it 'enqueues MagicRecipeJob and redirects with notice' do
+          recipe = create(:recipe, :processing_failed, :magic)
+          run    = create(:ai_classifier_run, :with_recipe, recipe: recipe)
+
+          expect do
+            post :rerun, params: { id: run.id }
+          end.to have_enqueued_job(MagicRecipeJob).with(recipe.id)
+
+          expect(response).to redirect_to(admin_ai_classifier_run_path(run))
+          expect(flash[:notice]).to eq('Recipe re-enqueued for processing.')
+        end
+      end
+
+      context 'when run has no associated recipe' do
+        it 'redirects with alert' do
+          run = create(:ai_classifier_run)
+
+          post :rerun, params: { id: run.id }
+
+          expect(response).to redirect_to(admin_ai_classifier_run_path(run))
+          expect(flash[:alert]).to eq('No associated recipe to rerun.')
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/magic_recipe_job_spec.rb
+++ b/spec/jobs/magic_recipe_job_spec.rb
@@ -25,7 +25,7 @@ describe MagicRecipeJob do
   end
 
   before do
-    allow(RecipeTextExtractor).to receive(:from_url).and_return('some recipe text')
+    allow(RecipeTextExtractor).to receive(:from_url).with(anything, recipe: anything).and_return('some recipe text')
     allow(RecipeAiExtractor).to receive(:extract).and_return(ai_result)
   end
 
@@ -58,12 +58,12 @@ describe MagicRecipeJob do
     let(:recipe) { create(:recipe, :draft, source_text: 'Some text', directions: nil) }
 
     it 'uses source_text directly' do
-      allow(RecipeAiExtractor).to receive(:extract).with('Some text').and_return(ai_result)
+      allow(RecipeAiExtractor).to receive(:extract).with('Some text', recipe: recipe).and_return(ai_result)
 
       described_class.perform_now(recipe.id)
 
       expect(RecipeTextExtractor).not_to have_received(:from_url)
-      expect(RecipeAiExtractor).to have_received(:extract).with('Some text')
+      expect(RecipeAiExtractor).to have_received(:extract).with('Some text', recipe: recipe)
     end
   end
 
@@ -72,12 +72,11 @@ describe MagicRecipeJob do
       allow(RecipeAiExtractor).to receive(:extract).and_raise(StandardError, 'API error')
     end
 
-    it 'sets ai_error and status to processing_failed' do
+    it 'sets status to processing_failed' do
       described_class.perform_now(recipe.id)
 
       recipe.reload
       expect(recipe.status).to eq('processing_failed')
-      expect(recipe.ai_error).to eq('API error')
     end
   end
 end

--- a/spec/models/ai_classifier_run_spec.rb
+++ b/spec/models/ai_classifier_run_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe AiClassifierRun do
+  describe 'associations' do
+    it { should belong_to(:recipe).optional }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:service_class) }
+    it { should validate_inclusion_of(:service_class).in_array(AiClassifierRun::SERVICE_CLASSES) }
+    it { should validate_inclusion_of(:adapter).in_array(AiClassifierRun::ADAPTERS).allow_nil }
+    it { should validate_inclusion_of(:success).in_array([true, false]) }
+
+    describe 'ai_model presence when adapter is set' do
+      it 'is valid with no adapter and no ai_model' do
+        run = build_stubbed(:ai_classifier_run, :text_extractor, ai_model: nil)
+        expect(run).to be_valid
+      end
+
+      it 'requires ai_model when adapter is present' do
+        run = build_stubbed(:ai_classifier_run, adapter: 'anthropic', ai_model: nil)
+        expect(run).not_to be_valid
+        expect(run.errors[:ai_model]).to be_present
+      end
+    end
+  end
+
+  describe '#in_progress?' do
+    it 'returns true when completed_at is nil' do
+      run = build_stubbed(:ai_classifier_run, completed_at: nil)
+      expect(run.in_progress?).to be true
+    end
+
+    it 'returns false when completed_at is set' do
+      run = build_stubbed(:ai_classifier_run, completed_at: Time.current)
+      expect(run.in_progress?).to be false
+    end
+  end
+
+  describe 'scopes' do
+    let!(:successful_run) { create(:ai_classifier_run, success: true) }
+    let!(:failed_run)     { create(:ai_classifier_run, :failed) }
+
+    describe '.successful' do
+      it 'returns only successful runs' do
+        expect(described_class.successful).to contain_exactly(successful_run)
+      end
+    end
+
+    describe '.failed' do
+      it 'returns only failed runs' do
+        expect(described_class.failed).to contain_exactly(failed_run)
+      end
+    end
+
+    describe '.by_success' do
+      it 'filters by true when passed "true"' do
+        expect(described_class.by_success('true')).to contain_exactly(successful_run)
+      end
+
+      it 'filters by false when passed "false"' do
+        expect(described_class.by_success('false')).to contain_exactly(failed_run)
+      end
+
+      it 'returns all when passed an invalid value' do
+        result = described_class.by_success('invalid')
+        expect(result).to include(successful_run, failed_run)
+      end
+    end
+
+    describe '.recent' do
+      it 'orders by created_at descending' do
+        older = create(:ai_classifier_run, created_at: 1.hour.ago)
+        newer = create(:ai_classifier_run, created_at: 1.minute.ago)
+        scoped = described_class.recent.where(id: [older.id, newer.id])
+        expect(scoped.first).to eq(newer)
+        expect(scoped.last).to eq(older)
+      end
+    end
+
+    describe '.for_recipe' do
+      it 'returns runs for the given recipe_id' do
+        recipe = create(:recipe)
+        run    = create(:ai_classifier_run, :with_recipe, recipe: recipe)
+        other  = create(:ai_classifier_run)
+
+        expect(described_class.for_recipe(recipe.id)).to contain_exactly(run)
+        expect(described_class.for_recipe(recipe.id)).not_to include(other)
+      end
+    end
+  end
+
+  describe '#duration_ms' do
+    it 'returns nil when started_at is missing' do
+      run = build_stubbed(:ai_classifier_run, started_at: nil, completed_at: Time.current)
+      expect(run.duration_ms).to be_nil
+    end
+
+    it 'returns nil when completed_at is missing' do
+      run = build_stubbed(:ai_classifier_run, started_at: Time.current, completed_at: nil)
+      expect(run.duration_ms).to be_nil
+    end
+
+    it 'returns duration in milliseconds' do
+      started    = Time.current
+      completed  = started + 2.5
+      run = build_stubbed(:ai_classifier_run, started_at: started, completed_at: completed)
+      expect(run.duration_ms).to eq(2500)
+    end
+  end
+
+  describe '#recipe_name' do
+    it 'returns the recipe name when recipe is present' do
+      recipe = build_stubbed(:recipe, name: 'Pasta Carbonara')
+      run    = build_stubbed(:ai_classifier_run, recipe: recipe)
+      expect(run.recipe_name).to eq('Pasta Carbonara')
+    end
+
+    it 'returns fallback text when recipe is nil' do
+      run = build_stubbed(:ai_classifier_run, recipe: nil)
+      expect(run.recipe_name).to eq('(recipe deleted)')
+    end
+  end
+end

--- a/spec/services/recipe_ai_applier_spec.rb
+++ b/spec/services/recipe_ai_applier_spec.rb
@@ -101,4 +101,47 @@ describe RecipeAiApplier do
       expect(recipe.ingredients.map(&:name)).to eq(['milk'])
     end
   end
+
+  describe 'AiClassifierRun recording' do
+    it 'creates a run with service_class RecipeAiApplier' do
+      expect { described_class.apply(recipe, data) }.to change(AiClassifierRun, :count).by(1)
+
+      run = AiClassifierRun.includes(:recipe).last
+      expect(run.service_class).to eq('RecipeAiApplier')
+      expect(run.recipe).to eq(recipe)
+      expect(run.adapter).to be_nil
+      expect(run.ai_model).to be_nil
+    end
+
+    it 'records a successful run with completed_at' do
+      described_class.apply(recipe, data)
+
+      run = AiClassifierRun.last
+      expect(run.success).to be true
+      expect(run.started_at).not_to be_nil
+      expect(run.completed_at).not_to be_nil
+    end
+
+    it 'stores data as JSON in user_prompt' do
+      described_class.apply(recipe, data)
+
+      run = AiClassifierRun.last
+      expect(run.user_prompt).to eq(data.to_json)
+    end
+
+    context 'when save! raises' do
+      it 'records a failed run and re-raises' do
+        # Stub save! on this specific recipe instance (avoids any_instance interfering with
+        # FactoryBot's lazy let evaluation which also calls save! on Recipe).
+        allow(recipe).to receive(:save!).and_raise(RuntimeError, 'save failed')
+
+        expect { described_class.apply(recipe, data) }.to raise_error(RuntimeError, 'save failed')
+
+        run = AiClassifierRun.last
+        expect(run.success).to be false
+        expect(run.error_class).to eq('RuntimeError')
+        expect(run.completed_at).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/recipe_ai_extractor_spec.rb
+++ b/spec/services/recipe_ai_extractor_spec.rb
@@ -2,62 +2,128 @@ require 'spec_helper'
 
 # rubocop:disable RSpec/VerifiedDoubles
 describe RecipeAiExtractor do
+  let(:text) { 'A recipe for chocolate cake with flour and sugar' }
+  let(:json_response) do
+    {
+      'name' => 'Chocolate Cake',
+      'directions' => '1. Mix ingredients',
+      'ingredients' => [{ 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour', 'descriptor' => 'sifted' }]
+    }
+  end
+
   describe '.extract' do
-    let(:text) { 'A recipe for chocolate cake with flour and sugar' }
-    let(:json_response) do
-      {
-        'name' => 'Chocolate Cake',
-        'directions' => '1. Mix ingredients',
-        'ingredients' => [{ 'quantity' => '2', 'unit' => 'cups', 'name' => 'flour', 'descriptor' => 'sifted' }]
-      }
-    end
+    context 'with the anthropic adapter (default)' do
+      before { ENV['ANTHROPIC_API_KEY'] = 'test-key' }
 
-    before do
-      ENV['ANTHROPIC_API_KEY'] = 'test-key'
-    end
+      after { ENV.delete('RECIPE_AI_ADAPTER') }
 
-    it 'sends text to Claude API and returns parsed JSON' do
-      mock_content = double('content', text: json_response.to_json)
-      mock_response = double('response', content: [mock_content])
-      mock_messages = double('messages')
-      mock_client = double('client', messages: mock_messages)
+      it 'sends text to Claude API and returns parsed JSON' do
+        mock_content = double('content', text: json_response.to_json)
+        mock_response = double('response', content: [mock_content])
+        mock_messages = double('messages')
+        mock_client = double('client', messages: mock_messages)
 
-      allow(Anthropic::Client).to receive(:new).and_return(mock_client)
-      allow(mock_messages).to receive(:create).and_return(mock_response)
+        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+        allow(mock_messages).to receive(:create).and_return(mock_response)
 
-      result = described_class.extract(text)
+        result = described_class.extract(text)
 
-      expect(result).to eq(json_response)
-      expect(mock_messages).to have_received(:create).with(
-        hash_including(
-          model: 'claude-sonnet-4-5-20250929',
-          messages: array_including(hash_including(role: 'user'))
+        expect(result).to eq(json_response)
+        expect(mock_messages).to have_received(:create).with(
+          hash_including(
+            model: 'claude-sonnet-4-5-20250929',
+            messages: array_including(hash_including(role: 'user'))
+          )
         )
-      )
+      end
+
+      it 'strips ```json fences from response' do
+        wrapped = "```json\n#{json_response.to_json}\n```"
+        mock_content = double('content', text: wrapped)
+        mock_response = double('response', content: [mock_content])
+        mock_messages = double('messages', create: mock_response)
+        mock_client = double('client', messages: mock_messages)
+
+        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+
+        expect(described_class.extract(text)).to eq(json_response)
+      end
+
+      it 'strips bare ``` fences from response' do
+        wrapped = "```\n#{json_response.to_json}\n```"
+        mock_content = double('content', text: wrapped)
+        mock_response = double('response', content: [mock_content])
+        mock_messages = double('messages', create: mock_response)
+        mock_client = double('client', messages: mock_messages)
+
+        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+
+        expect(described_class.extract(text)).to eq(json_response)
+      end
     end
 
-    it 'strips ```json fences from response' do
-      wrapped = "```json\n#{json_response.to_json}\n```"
-      mock_content = double('content', text: wrapped)
-      mock_response = double('response', content: [mock_content])
-      mock_messages = double('messages', create: mock_response)
-      mock_client = double('client', messages: mock_messages)
+    context 'with the ollama adapter' do
+      around do |example|
+        ENV['RECIPE_AI_ADAPTER'] = 'ollama'
+        ENV['OLLAMA_URL'] = 'http://localhost:11434'
+        ENV['OLLAMA_MODEL'] = 'llama3.2'
+        example.run
+        ENV.delete('RECIPE_AI_ADAPTER')
+        ENV.delete('OLLAMA_URL')
+        ENV.delete('OLLAMA_MODEL')
+      end
 
-      allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+      let(:ollama_response) do
+        { 'message' => { 'content' => json_response.to_json } }.to_json
+      end
 
-      expect(described_class.extract(text)).to eq(json_response)
-    end
+      it 'sends text to Ollama and returns parsed JSON' do
+        stub_request(:post, 'http://localhost:11434/api/chat')
+          .with(
+            headers: { 'Content-Type' => 'application/json' },
+            body: hash_including(
+              'model' => 'llama3.2',
+              'stream' => false,
+              'messages' => array_including(hash_including('role' => 'system'))
+            )
+          )
+          .to_return(status: 200, body: ollama_response, headers: { 'Content-Type' => 'application/json' })
 
-    it 'strips bare ``` fences from response' do
-      wrapped = "```\n#{json_response.to_json}\n```"
-      mock_content = double('content', text: wrapped)
-      mock_response = double('response', content: [mock_content])
-      mock_messages = double('messages', create: mock_response)
-      mock_client = double('client', messages: mock_messages)
+        result = described_class.extract(text)
 
-      allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+        expect(result).to eq(json_response)
+      end
 
-      expect(described_class.extract(text)).to eq(json_response)
+      it 'raises on non-200 response' do
+        stub_request(:post, 'http://localhost:11434/api/chat')
+          .to_return(status: 500, body: 'Internal Server Error')
+
+        expect { described_class.extract(text) }.to raise_error(/Ollama request failed \(500\)/)
+      end
+
+      it 'uses a custom model from OLLAMA_MODEL' do
+        ENV['OLLAMA_MODEL'] = 'mistral'
+
+        stub_request(:post, 'http://localhost:11434/api/chat')
+          .with(body: hash_including('model' => 'mistral'))
+          .to_return(status: 200, body: ollama_response)
+
+        described_class.extract(text)
+
+        expect(a_request(:post, 'http://localhost:11434/api/chat')
+          .with(body: hash_including('model' => 'mistral'))).to have_been_made
+      end
+
+      it 'uses a custom base URL from OLLAMA_URL' do
+        ENV['OLLAMA_URL'] = 'http://my-server:11434'
+
+        stub_request(:post, 'http://my-server:11434/api/chat')
+          .to_return(status: 200, body: ollama_response)
+
+        described_class.extract(text)
+
+        expect(a_request(:post, 'http://my-server:11434/api/chat')).to have_been_made
+      end
     end
   end
 end

--- a/spec/services/recipe_ai_extractor_spec.rb
+++ b/spec/services/recipe_ai_extractor_spec.rb
@@ -13,9 +13,10 @@ describe RecipeAiExtractor do
 
   describe '.extract' do
     context 'with the anthropic adapter (default)' do
-      before { ENV['ANTHROPIC_API_KEY'] = 'test-key' }
-
-      after { ENV.delete('RECIPE_AI_ADAPTER') }
+      before do
+        ENV['ANTHROPIC_API_KEY'] = 'test-key'
+        ENV.delete('RECIPE_AI_ADAPTER')
+      end
 
       it 'sends text to Claude API and returns parsed JSON' do
         mock_content = double('content', text: json_response.to_json)
@@ -68,6 +69,7 @@ describe RecipeAiExtractor do
         ENV['OLLAMA_URL'] = 'http://localhost:11434'
         ENV['OLLAMA_MODEL'] = 'llama3.2'
         example.run
+      ensure
         ENV.delete('RECIPE_AI_ADAPTER')
         ENV.delete('OLLAMA_URL')
         ENV.delete('OLLAMA_MODEL')

--- a/spec/services/recipe_ai_extractor_spec.rb
+++ b/spec/services/recipe_ai_extractor_spec.rb
@@ -11,120 +11,114 @@ describe RecipeAiExtractor do
     }
   end
 
+  def stub_ruby_llm(content:)
+    mock_response = double('response', content: content)
+    mock_chat     = double('chat', with_instructions: nil, ask: mock_response)
+    allow(RubyLLM).to receive(:chat).and_return(mock_chat)
+    mock_chat
+  end
+
   describe '.extract' do
-    context 'with the anthropic adapter (default)' do
-      before do
-        ENV['ANTHROPIC_API_KEY'] = 'test-key'
-        ENV.delete('RECIPE_AI_ADAPTER')
+    before do
+      ENV['ANTHROPIC_API_KEY'] = 'test-key'
+    end
+
+    it 'sends text to Claude API and returns parsed JSON' do
+      mock_chat = stub_ruby_llm(content: json_response.to_json)
+
+      result = described_class.extract(text)
+
+      expect(result).to eq(json_response)
+      expect(RubyLLM).to have_received(:chat).with(model: 'claude-haiku-4-5-20251001')
+      expect(mock_chat).to have_received(:with_instructions).with(RecipeAiExtractor::SYSTEM_PROMPT)
+      expect(mock_chat).to have_received(:ask).with(including(text))
+    end
+
+    it 'uses a custom model from ANTHROPIC_MODEL' do
+      ENV['ANTHROPIC_MODEL'] = 'claude-sonnet-4-6'
+      stub_ruby_llm(content: json_response.to_json)
+
+      described_class.extract(text)
+
+      expect(RubyLLM).to have_received(:chat).with(model: 'claude-sonnet-4-6')
+    ensure
+      ENV.delete('ANTHROPIC_MODEL')
+    end
+
+    it 'strips ```json fences from response' do
+      stub_ruby_llm(content: "```json\n#{json_response.to_json}\n```")
+      expect(described_class.extract(text)).to eq(json_response)
+    end
+
+    it 'strips bare ``` fences from response' do
+      stub_ruby_llm(content: "```\n#{json_response.to_json}\n```")
+      expect(described_class.extract(text)).to eq(json_response)
+    end
+  end
+
+  describe 'AiClassifierRun recording' do
+    before do
+      ENV['ANTHROPIC_API_KEY'] = 'test-key'
+    end
+
+    context 'on success with anthropic adapter' do
+      it 'creates a successful AiClassifierRun with correct metadata' do
+        stub_ruby_llm(content: json_response.to_json)
+
+        expect { described_class.extract(text) }.to change(AiClassifierRun, :count).by(1)
+
+        run = AiClassifierRun.last
+        expect(run.service_class).to eq('RecipeAiExtractor')
+        expect(run.success).to be true
+        expect(run.adapter).to eq('anthropic')
+        expect(run.ai_model).to eq('claude-haiku-4-5-20251001')
+        expect(run.system_prompt).to eq(RecipeAiExtractor::SYSTEM_PROMPT)
+        expect(run.user_prompt).to include(text)
+        expect(run.raw_response).to eq(json_response.to_json)
+        expect(run.started_at).not_to be_nil
+        expect(run.completed_at).not_to be_nil
+        expect(run.error_class).to be_nil
+        expect(run.error_message).to be_nil
       end
 
-      it 'sends text to Claude API and returns parsed JSON' do
-        mock_content = double('content', text: json_response.to_json)
-        mock_response = double('response', content: [mock_content])
-        mock_messages = double('messages')
-        mock_client = double('client', messages: mock_messages)
+      it 'persists the run immediately (before LLM call completes)' do
+        # The run should be saved with success: false before we get a response
+        call_count = 0
+        allow(AiClassifierRun).to receive(:create!).and_wrap_original do |orig, **attrs|
+          call_count += 1
+          expect(AiClassifierRun.count).to eq(call_count - 1) if call_count == 1
+          orig.call(**attrs)
+        end
 
-        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
-        allow(mock_messages).to receive(:create).and_return(mock_response)
-
-        result = described_class.extract(text)
-
-        expect(result).to eq(json_response)
-        expect(mock_messages).to have_received(:create).with(
-          hash_including(
-            model: 'claude-sonnet-4-5-20250929',
-            messages: array_including(hash_including(role: 'user'))
-          )
-        )
+        stub_ruby_llm(content: json_response.to_json)
+        described_class.extract(text)
       end
 
-      it 'strips ```json fences from response' do
-        wrapped = "```json\n#{json_response.to_json}\n```"
-        mock_content = double('content', text: wrapped)
-        mock_response = double('response', content: [mock_content])
-        mock_messages = double('messages', create: mock_response)
-        mock_client = double('client', messages: mock_messages)
+      it 'associates the run with the provided recipe' do
+        recipe = create(:recipe)
+        stub_ruby_llm(content: json_response.to_json)
 
-        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+        described_class.extract(text, recipe: recipe)
 
-        expect(described_class.extract(text)).to eq(json_response)
-      end
-
-      it 'strips bare ``` fences from response' do
-        wrapped = "```\n#{json_response.to_json}\n```"
-        mock_content = double('content', text: wrapped)
-        mock_response = double('response', content: [mock_content])
-        mock_messages = double('messages', create: mock_response)
-        mock_client = double('client', messages: mock_messages)
-
-        allow(Anthropic::Client).to receive(:new).and_return(mock_client)
-
-        expect(described_class.extract(text)).to eq(json_response)
+        expect(AiClassifierRun.includes(:recipe).last.recipe).to eq(recipe)
       end
     end
 
-    context 'with the ollama adapter' do
-      around do |example|
-        ENV['RECIPE_AI_ADAPTER'] = 'ollama'
-        ENV['OLLAMA_URL'] = 'http://localhost:11434'
-        ENV['OLLAMA_MODEL'] = 'llama3.2'
-        example.run
-      ensure
-        ENV.delete('RECIPE_AI_ADAPTER')
-        ENV.delete('OLLAMA_URL')
-        ENV.delete('OLLAMA_MODEL')
-      end
+    context 'on failure with anthropic adapter' do
+      it 'creates a failed AiClassifierRun and re-raises the error' do
+        mock_chat = double('chat', with_instructions: nil)
+        allow(mock_chat).to receive(:ask).and_raise(RuntimeError, 'connection refused')
+        allow(RubyLLM).to receive(:chat).and_return(mock_chat)
 
-      let(:ollama_response) do
-        { 'message' => { 'content' => json_response.to_json } }.to_json
-      end
+        expect { described_class.extract(text) }.to raise_error(RuntimeError, 'connection refused')
 
-      it 'sends text to Ollama and returns parsed JSON' do
-        stub_request(:post, 'http://localhost:11434/api/chat')
-          .with(
-            headers: { 'Content-Type' => 'application/json' },
-            body: hash_including(
-              'model' => 'llama3.2',
-              'stream' => false,
-              'messages' => array_including(hash_including('role' => 'system'))
-            )
-          )
-          .to_return(status: 200, body: ollama_response, headers: { 'Content-Type' => 'application/json' })
-
-        result = described_class.extract(text)
-
-        expect(result).to eq(json_response)
-      end
-
-      it 'raises on non-200 response' do
-        stub_request(:post, 'http://localhost:11434/api/chat')
-          .to_return(status: 500, body: 'Internal Server Error')
-
-        expect { described_class.extract(text) }.to raise_error(/Ollama request failed \(500\)/)
-      end
-
-      it 'uses a custom model from OLLAMA_MODEL' do
-        ENV['OLLAMA_MODEL'] = 'mistral'
-
-        stub_request(:post, 'http://localhost:11434/api/chat')
-          .with(body: hash_including('model' => 'mistral'))
-          .to_return(status: 200, body: ollama_response)
-
-        described_class.extract(text)
-
-        expect(a_request(:post, 'http://localhost:11434/api/chat')
-          .with(body: hash_including('model' => 'mistral'))).to have_been_made
-      end
-
-      it 'uses a custom base URL from OLLAMA_URL' do
-        ENV['OLLAMA_URL'] = 'http://my-server:11434'
-
-        stub_request(:post, 'http://my-server:11434/api/chat')
-          .to_return(status: 200, body: ollama_response)
-
-        described_class.extract(text)
-
-        expect(a_request(:post, 'http://my-server:11434/api/chat')).to have_been_made
+        run = AiClassifierRun.last
+        expect(run.service_class).to eq('RecipeAiExtractor')
+        expect(run.success).to be false
+        expect(run.error_class).to eq('RuntimeError')
+        expect(run.error_message).to eq('connection refused')
+        expect(run.raw_response).to be_nil
+        expect(run.completed_at).not_to be_nil
       end
     end
   end

--- a/spec/services/recipe_text_extractor_spec.rb
+++ b/spec/services/recipe_text_extractor_spec.rb
@@ -73,4 +73,51 @@ describe RecipeTextExtractor do
       end.to raise_error(/HTTP 404/)
     end
   end
+
+  describe 'AiClassifierRun recording' do
+    let(:html) { '<html><body><article><p>Some recipe text</p></article></body></html>' }
+
+    before { stub_request(:get, url).to_return(status: 200, body: html) }
+
+    it 'creates a run with service_class RecipeTextExtractor' do
+      expect { described_class.from_url(url) }.to change(AiClassifierRun, :count).by(1)
+
+      run = AiClassifierRun.last
+      expect(run.service_class).to eq('RecipeTextExtractor')
+      expect(run.user_prompt).to eq(url)
+      expect(run.adapter).to be_nil
+      expect(run.ai_model).to be_nil
+    end
+
+    it 'records a successful run with raw_response and completed_at' do
+      described_class.from_url(url)
+
+      run = AiClassifierRun.last
+      expect(run.success).to be true
+      expect(run.raw_response).to include('Some recipe text')
+      expect(run.started_at).not_to be_nil
+      expect(run.completed_at).not_to be_nil
+    end
+
+    it 'associates the run with the provided recipe' do
+      recipe = create(:recipe)
+      described_class.from_url(url, recipe: recipe)
+
+      expect(AiClassifierRun.includes(:recipe).last.recipe).to eq(recipe)
+    end
+
+    context 'when an HTTP error occurs' do
+      before { stub_request(:get, url).to_return(status: 404) }
+
+      it 'records a failed run and re-raises' do
+        expect { described_class.from_url(url) }.to raise_error(/HTTP 404/)
+
+        run = AiClassifierRun.last
+        expect(run.success).to be false
+        expect(run.error_class).to be_present
+        expect(run.error_message).to include('404')
+        expect(run.completed_at).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -50,7 +50,6 @@ FactoryBot.define do
     trait :processing_failed do
       status { 'processing_failed' }
       directions { nil }
-      ai_error { 'AI extraction failed' }
     end
 
     trait :review do
@@ -81,5 +80,37 @@ FactoryBot.define do
     recipe
     ingredient
     descriptor { nil }
+  end
+
+  factory :ai_classifier_run do
+    service_class { 'RecipeAiExtractor' }
+    adapter       { 'anthropic' }
+    ai_model      { 'claude-sonnet-4-5-20250929' }
+    success       { true }
+    started_at    { 5.seconds.ago }
+    completed_at  { Time.current }
+
+    trait :failed do
+      success       { false }
+      error_class   { 'RuntimeError' }
+      error_message { 'API error' }
+      raw_response  { nil }
+    end
+
+    trait :with_recipe do
+      recipe
+    end
+
+    trait :text_extractor do
+      service_class { 'RecipeTextExtractor' }
+      adapter       { nil }
+      ai_model      { nil }
+    end
+
+    trait :ai_applier do
+      service_class { 'RecipeAiApplier' }
+      adapter       { nil }
+      ai_model      { nil }
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `AiClassifierRun` model to record every invocation of `RecipeTextExtractor`, `RecipeAiExtractor`, and `RecipeAiApplier` — capturing timing, prompts sent, raw response, and success/failure with error details
- Adds an admin UI to browse runs grouped by recipe, filter by success state, and view full prompt/response detail; includes a rerun action to re-enqueue a recipe
- Switches from the `anthropic` gem to `ruby_llm` with a `claude-haiku-4-5-20251001` default, overridable via `ANTHROPIC_MODEL`
- Removes the now-redundant `ai_error` column from recipes (error details live on `AiClassifierRun`)
- Improves the system prompt to handle "X or Y" ingredient alternatives: encodes the primary in `name`, the alternative as `"or [x]"` in `descriptor`, and surfaces both in the relevant directions step

## Test plan

- [ ] Run `bin/rake` — brakeman, bundler-audit, rubocop, rspec all pass
- [ ] Import a recipe via New Magic Recipe and confirm an `AiClassifierRun` record appears in the admin runs index linked to the recipe
- [ ] Verify run counts appear on the admin recipe index and link to filtered runs
- [ ] Test a recipe with an "X or Y" ingredient (e.g. beef or turkey) and confirm the extraction reflects the choice in both the ingredient list and directions
- [ ] Set `ANTHROPIC_MODEL=claude-sonnet-4-6` and confirm the run record logs the overridden model