### PR TITLE
Add user onboarding: username, email confirmation, and admin approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 MilkSteak is a recipe tracker Rails app. Users can create recipes with ingredients, images, directions, and tags (cooking methods, courses, cultural influences, dietary restrictions). Recipes are browsable with tag-based filtering and pagination. Admins can import recipes from URLs or pasted text via AI extraction (Anthropic Claude).
 
+New users sign up with an email and a unique public username; accounts require admin approval before they can sign in. Admins manage pending users via `/admin/users`.
+
 ## Tech Stack
 
 - **Ruby 4.0.1** / **Rails 8.0**
@@ -51,20 +53,24 @@ bin/screenshots
 ## Project Structure
 
 ### Models
-- `app/models/recipe.rb` — Core model with status workflow, tagging, nested attributes
+- `app/models/recipe.rb` — Core model with status workflow, tagging, nested attributes; delegates `email` and `username` to user (prefix: true)
 - `app/models/image.rb` — Active Storage attachment with type/size validation; variants: `:tiny` (32x32), `:thumb` (187x187), `:large` (800x600)
 - `app/models/ingredient.rb` — Ingredient names, linked to recipes via RecipeIngredient
-- `app/models/recipe_ingredient.rb` — Join model with quantity, unit, section; ordered via `acts_as_list` scoped by recipe and section
-- `app/models/user.rb` — Devise user with `admin?` flag
-- `app/models/filter_set.rb` — PORO (ActiveModel::Model) for compound recipe filtering (tags, name, ingredients, author)
+- `app/models/recipe_ingredient.rb` — Join model with quantity (max 10 chars), unit, descriptor, section; ordered via `acts_as_list` scoped by recipe and section
+- `app/models/user.rb` — Devise user with `username` (unique, 3–30 chars, letters/numbers/underscores), `admin` flag, and `approved` flag. Key methods: `approved?` (always true for admins), `active_for_authentication?` (gates sign-in for unapproved users), `inactive_message` (returns `:pending_approval` symbol for Devise i18n). Pending admins bypass the approval gate — the admin flag is checked first.
+- `app/models/ai_classifier_run.rb` — Persisted record of every AI pipeline call (RecipeTextExtractor, RecipeAiExtractor, RecipeAiApplier); stores adapter, model, system_prompt, user_prompt, raw_response, timing, success/failure
+- `app/models/filter_set.rb` — PORO (ActiveModel::Model) for compound recipe filtering (tags, name, ingredients, author); author filter uses `users.username ilike ?` (case-insensitive partial match)
 - `app/models/featured_image_chooser.rb` — PORO for selecting featured recipe images
 - `app/models/tag_finder.rb` — PORO for querying tags by context
 
 ### Controllers
-- `app/controllers/recipes_controller.rb` — Main CRUD with ownership-based authorization
+- `app/controllers/application_controller.rb` — `configure_permitted_parameters` permits `:username` on Devise sign_up; `require_approved!` signs out and redirects any authenticated user whose `approved?` returns false
+- `app/controllers/recipes_controller.rb` — Main CRUD with ownership-based authorization; `require_approved!` fires before new/create/edit/update
 - `app/controllers/admin/base_controller.rb` — Admin auth via `current_user&.admin?` before_action
 - `app/controllers/admin/recipes_controller.rb` — Admin recipe management (publish, reject, reprocess, destroy)
 - `app/controllers/admin/magic_recipes_controller.rb` — AI recipe import (new, create)
+- `app/controllers/admin/users_controller.rb` — User management: index lists pending and approved non-admin users; approve patches `approved: true`
+- `app/controllers/admin/ai_classifier_runs_controller.rb` — AI run history with filtering, pagination, and per-recipe grouping; rerun action re-enqueues MagicRecipeJob
 - `app/controllers/autocompletes/` — JSON endpoints for tags, ingredients, units, serving units
 
 ### Services
@@ -77,7 +83,11 @@ bin/screenshots
 
 ### Key Views / Partials
 - `app/views/recipes/_control_panel.html.erb` — Role-aware action bar on recipe#show; renders for the recipe owner (Edit) or any admin (status badge + Edit + Publish/Reject/Reprocess/Delete gated on workflow state)
-- `app/views/admin/recipes/index.html.erb` — Admin recipe list with unified status-filter/action bar
+- `app/views/recipes/_show_content.html.erb` — Recipe detail; author shown as `user_username` (not email), linked to author filter
+- `app/views/admin/recipes/index.html.erb` — Admin recipe list with unified status-filter/action bar; nav bar includes Users and AI Runs links
+- `app/views/admin/users/index.html.erb` — Pending and approved user lists with approve buttons
+- `app/views/admin/ai_classifier_runs/` — AI run index (grouped by recipe) and show (full prompt/response detail)
+- `app/views/devise/registrations/new.html.erb` — Custom registration form that includes the username field (Simple Form)
 
 ### Config
 - `config/initializers/content_security_policy.rb` — CSP enforced
@@ -88,8 +98,10 @@ bin/screenshots
 
 - `root` → `recipes#index`
 - `resources :recipes` — index, new, create, show, edit, update (no destroy for non-admin)
+- `admin/users` — index, plus member route: approve (patch)
 - `admin/recipes` — index, destroy, plus member routes: publish, reject, reprocess
 - `admin/magic_recipes` — new, create (AI import)
+- `admin/ai_classifier_runs` — index, show, plus member route: rerun (post)
 - `autocompletes/` — index-only resources for cooking_methods, cultural_influences, courses, dietary_restrictions, serving_units, ingredient_units, ingredient_names
 - `/up` — Rails 8 health check
 
@@ -113,6 +125,8 @@ Recipes have a `status` field with values: `draft`, `processing`, `processing_fa
 - `strict_loading_by_default` enabled in test environment to catch N+1 queries
 - Prefer `build_stubbed` over `create` in unit/controller specs for performance
 - When stubbing `find_recipe`, stub `Recipe.includes` (not `Recipe.find`) since the controller chains `.includes(...).find(id)`
+- User factory defaults: `approved: true`, auto-generated `username` (sequence `user1`, `user2`, …); use the `:pending` trait for `approved: false`; `:admin` trait sets `admin: true`
+- The `sign_in_user` controller helper mocks `current_user` directly — it bypasses Devise auth entirely, so `active_for_authentication?` is not exercised in controller specs
 
 ## Linting & Security
 
@@ -128,6 +142,7 @@ Recipes have a `status` field with values: `draft`, `processing`, `processing_fa
 - Recipes use `acts_as_taggable_on` with four tag contexts, all force-lowercased with auto-cleanup of unused tags
 - Nested attributes: Recipe accepts nested RecipeIngredients and Images
 - RecipeIngredients ordered via `acts_as_list`, scoped by recipe and section
+- `RecipeIngredient#quantity` is max 10 characters — AI prompts must enforce this; use digits/fractions/hyphens only (e.g. `"1 1/2"`, `"2-3"`, `"to taste"`)
 - Image uploads validated for type (JPEG, PNG, WebP, AVIF, HEIC/HEIF) and size (max 10MB)
 - Security headers in `config/application.rb`: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy
 - CSP enforced via `content_security_policy.rb`
@@ -136,6 +151,8 @@ Recipes have a `status` field with values: `draft`, `processing`, `processing_fa
 - Use `Recipe.includes(...)` for eager loading associations (not `Preloader`)
 - Markdown rendered via Redcarpet with `safe_links_only` and `escape_html`
 - Tagging associations exempted from strict loading (gem uses lazy loading internally)
+- Devise approval pattern: override `active_for_authentication?` and `inactive_message` on User; the `:pending_approval` symbol maps to `devise.failure.pending_approval` in `config/locales/devise.en.yml`; admins bypass the gate via `approved?` short-circuiting on `admin?`
+- AI pipeline observability: every call to RecipeTextExtractor, RecipeAiExtractor, and RecipeAiApplier creates an `AiClassifierRun` record before the operation starts (`success: false`), then updates it on completion; viewable at `/admin/ai_classifier_runs`
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ MilkSteak is a recipe tracker web application built with love.
 
 - Create and edit recipes with ingredients, directions, images, and descriptions
 - Tag recipes across four facets: cooking methods, courses, cultural influences, and dietary restrictions
-- Browse and filter recipes by tags, name, ingredients, and author
+- Browse and filter recipes by tags, name, ingredients, and author username
 - Autocomplete for tags, ingredients, units, and serving units
 - AI-powered recipe import from URLs or pasted text (admin only, via Anthropic Claude)
 - Role-aware control panel on recipe pages: owners see Edit; admins see status badge and workflow actions (Publish, Reject, Reprocess, Delete)
 - Admin workflow for reviewing, publishing, and rejecting recipes
 - Image uploads with automatic variant generation (thumbnails, large)
 - Pagination and SEO-friendly recipe URLs
-- User authentication with Devise
+- User accounts with email confirmation (Devise); new users are pending until an admin approves them
+- Unique public username collected at signup; shown on recipes instead of email address
+- Admin user management: view pending and approved users, approve pending accounts
 
 ## Screenshots
 
@@ -116,7 +118,9 @@ See [docs/models.md](docs/models.md) for the full ER diagram.
 | Component | Description |
 |---|---|
 | `Recipe` | Core model with statuses: `draft`, `processing`, `processing_failed`, `review`, `published`, `rejected` |
-| `FilterSet` | PORO for compound recipe filtering (tags, name, ingredients, author) |
+| `User` | Devise user with username, admin flag, and approval workflow |
+| `FilterSet` | PORO for compound recipe filtering (tags, name, ingredients, author username) |
+| `AiClassifierRun` | Persisted record of every AI pipeline invocation with timing, prompts, and outcome |
 | `MagicRecipeJob` | Background job that extracts recipe data from URLs/text via Claude |
 | `RecipeAiExtractor` | Sends source content to Anthropic API and parses structured response |
 | `RecipeAiApplier` | Applies AI-extracted data to a Recipe (ingredients, tags, directions) |

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,14 @@
+module Admin
+  class UsersController < BaseController
+    def index
+      @pending_users  = User.where(approved: false, admin: false).order(:created_at)
+      @approved_users = User.where(approved: true,  admin: false).order(:created_at)
+    end
+
+    def approve
+      @user = User.find(params[:id])
+      @user.update!(approved: true)
+      redirect_to admin_users_path, notice: "#{@user.username} has been approved."
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,24 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
 
   def redirect_to_login
     redirect_to new_user_session_path and return
+  end
+
+  def require_approved!
+    return unless current_user
+    return if current_user.approved?
+
+    sign_out current_user
+    redirect_to new_user_session_path, alert: I18n.t('devise.failure.pending_approval')
   end
 
   def forbidden

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,7 +1,8 @@
 class RecipesController < ApplicationController
   before_action :redirect_to_login,
-    if: -> {current_user.blank?},
+    if: -> { current_user.blank? },
     only: [:new, :update, :create, :edit]
+  before_action :require_approved!, only: [:new, :create, :edit, :update]
   before_action :find_recipe, only: [:show, :edit, :update]
   before_action :can_update, only: [:edit, :update]
   before_action :ensure_visible, only: [:show]

--- a/app/models/filter_set.rb
+++ b/app/models/filter_set.rb
@@ -44,7 +44,7 @@ class FilterSet
     end
     if author.present?
       recipes = recipes.joins(:user).where(
-        'users.email like ?', author.downcase
+        'users.username ilike ?', "%#{author}%"
       )
     end
     recipes.distinct

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -47,7 +47,8 @@ class Recipe < ApplicationRecord
   validates :source_url, format: { with: /\Ahttps?:\/\/\S+\z/i, message: 'must be an HTTP(S) URL' },
                          allow_blank: true
 
-  delegate :email, to: :user, prefix: true, allow_nil: true
+  delegate :email,    to: :user, prefix: true, allow_nil: true
+  delegate :username, to: :user, prefix: true, allow_nil: true
 
   def name_for_url
     name.downcase.gsub(/[^a-z\d ]/i,'').gsub(' ','_')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,25 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   validates :email, email: true, presence: true, uniqueness: true
+  validates :username, presence: true,
+                       uniqueness: { case_sensitive: false },
+                       format: { with: /\A[a-z0-9_]+\z/i },
+                       length: { minimum: 3, maximum: 30 }
   has_many :recipes
 
   def admin?
     admin
+  end
+
+  def approved?
+    admin? || self[:approved]
+  end
+
+  def active_for_authentication?
+    super && approved?
+  end
+
+  def inactive_message
+    approved? ? super : :pending_approval
   end
 end

--- a/app/services/recipe_ai_extractor.rb
+++ b/app/services/recipe_ai_extractor.rb
@@ -25,8 +25,8 @@ class RecipeAiExtractor
     - Names should be the plain canonical ingredient only, lowercase (e.g. "onion", "garlic", "tomato"). No prep verbs, no quality adjectives, strip specific brand names
     - Put any preparation method or quality descriptor in the separate `descriptor` field, lowercase (e.g. "diced", "minced", "ripe", "fresh", "crushed"). Omit the field (or use null) if there is no descriptor
     - When the recipe offers a choice between two ingredients (e.g., "1 lb beef or turkey", "chicken or tofu"), list the primary (first-mentioned) option as the ingredient name. Encode the alternative in the descriptor field using the format "or [alternative]" (e.g., name: "beef", descriptor: "or turkey"). Do not create a separate ingredient entry for the alternative.
-    - Quantity should be a string that can include fractions like "1/2". Use "to taste" when no specific amount is given
-    - Unit should be a standard measurement (cup, tbsp, tsp, oz, lb, etc.) or empty string when not applicable (e.g. "2" "large" "eggs")
+    - Quantity is a string — MAXIMUM 10 CHARACTERS. Use only the numeric amount: digits, fractions, and hyphens for ranges (e.g. "1", "1/2", "1 1/2", "2-3", "1/4-1/2"). Never include the unit or any words in this field. Use "to taste" (8 chars) when no specific amount is given. For open-ended amounts use "as needed" (9 chars).
+    - Unit should be a standard abbreviation (cup, tbsp, tsp, oz, lb, g, kg, ml, L, etc.) or empty string when not applicable (e.g. "2" "large" "eggs"). Keep units concise.
     - Every ingredient in the list MUST be referenced in the directions. If the source text mentions an ingredient only in the directions but not in the ingredient list, add it to the ingredients list
 
     Sections:
@@ -36,12 +36,12 @@ class RecipeAiExtractor
     - Only use sections when the recipe clearly organizes ingredients into groups
 
     Description:
-    - 1-2 sentences describing the dish itself — what it is and what makes it good
+    - 1-2 sentences describing the dish itself — what it is and what makes it good. Maximum 2000 characters.
     - Do NOT include personal stories, anecdotes, recipe origin stories, or blog filler
     - Do NOT include tips, variations, serving suggestions, or storage instructions
 
     Directions:
-    - Clear numbered steps — ONLY actionable cooking instructions
+    - Clear numbered steps — ONLY actionable cooking instructions. Maximum 8000 characters total.
     - Strip out completely: life stories, personal anecdotes, blog filler, ads, "notes" sections, after-the-fact variation suggestions ("you could also substitute...", "feel free to swap..."), storage/reheating tips, and serving suggestions — but preserve "X or Y" choices that are stated as part of the original recipe
     - When a step uses an ingredient that has an alternative (where the recipe says "X or Y"), name both options explicitly in that step (e.g., "Brown the beef (or turkey) over medium heat" rather than "Brown the meat")
     - Reference ingredients by the same name used in the ingredients list for consistency

--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -15,6 +15,7 @@
                   count.zero? && !active ? 'opacity-50' : nil].compact.join(' ') %>
     <% end %>
     <div class="ml-auto flex items-center gap-x-3">
+      <%= link_to 'Users', admin_users_path, class: 'text-ink-light hover:text-terra no-underline font-medium text-sm' %>
       <%= link_to 'AI Runs', admin_ai_classifier_runs_path, class: 'text-ink-light hover:text-terra no-underline font-medium text-sm' %>
       <%= link_to new_admin_magic_recipe_path, class: 'inline-flex items-center gap-1.5 bg-terra-dark text-white px-3 py-1 rounded-lg no-underline hover:bg-terra font-medium transition-colors' do %>
         <span class="text-[1.5em] leading-none">🪄</span> New Magic Recipe
@@ -43,7 +44,7 @@
                 <span class="text-xs text-purple-600">(magic)</span>
               <% end %>
             </td>
-            <td class="px-4 py-3 text-ink-light"><%= recipe.user_email %></td>
+            <td class="px-4 py-3 text-ink-light"><%= recipe.user_username %></td>
             <td class="px-4 py-3"><%= render 'status_badge', status: recipe.status %></td>
             <td class="px-4 py-3 text-ink-light">
               <%= link_to @run_counts[recipe.id] || 0,

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,61 @@
+<div class="max-w-6xl mx-auto p-4 md:p-6">
+  <h1 class="text-3xl text-ink mb-6">Admin: Users</h1>
+
+  <% if @pending_users.any? %>
+    <section class="mb-8">
+      <h2 class="text-xl font-semibold text-ink mb-3">Pending Approval (<%= @pending_users.size %>)</h2>
+      <div class="bg-white rounded-xl shadow-sm overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 text-left">
+            <tr>
+              <th class="px-4 py-3 font-semibold text-ink">Username</th>
+              <th class="px-4 py-3 font-semibold text-ink">Email</th>
+              <th class="px-4 py-3 font-semibold text-ink">Signed up</th>
+              <th class="px-4 py-3 font-semibold text-ink">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <% @pending_users.each do |user| %>
+              <tr class="hover:bg-gray-50">
+                <td class="px-4 py-3 font-medium text-ink"><%= user.username %></td>
+                <td class="px-4 py-3 text-ink-light"><%= user.email %></td>
+                <td class="px-4 py-3 text-ink-light"><%= l(user.created_at, format: :default) %></td>
+                <td class="px-4 py-3">
+                  <%= button_to 'Approve', approve_admin_user_path(user), method: :patch,
+                        class: 'text-green-700 hover:underline bg-transparent border-0 cursor-pointer p-0 text-sm' %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% else %>
+    <p class="text-ink-light mb-8">No users pending approval.</p>
+  <% end %>
+
+  <section>
+    <h2 class="text-xl font-semibold text-ink mb-3">Approved Users (<%= @approved_users.size %>)</h2>
+    <div class="bg-white rounded-xl shadow-sm overflow-hidden">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-50 text-left">
+          <tr>
+            <th class="px-4 py-3 font-semibold text-ink">Username</th>
+            <th class="px-4 py-3 font-semibold text-ink">Email</th>
+            <th class="px-4 py-3 font-semibold text-ink">Signed up</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <% @approved_users.each do |user| %>
+            <tr class="hover:bg-gray-50">
+              <td class="px-4 py-3 font-medium text-ink"><%= user.username %></td>
+              <td class="px-4 py-3 text-ink-light"><%= user.email %></td>
+              <td class="px-4 py-3 text-ink-light"><%= l(user.created_at, format: :default) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+<% content_for(:page_title, 'Admin: Users') %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,28 @@
+<div class="max-w-md mx-auto p-6">
+  <h2 class="text-2xl text-ink mb-6">Sign Up</h2>
+
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= f.error_notification %>
+    <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+    <div class="space-y-4">
+      <%= f.input :email, required: true, autofocus: true, input_html: { autocomplete: 'email' } %>
+      <%= f.input :username, required: true,
+            hint: 'Letters, numbers, and underscores only. 3–30 characters. Shown publicly on recipes.',
+            input_html: { autocomplete: 'username' } %>
+      <%= f.input :password, required: true,
+            hint: ('8 characters minimum' if @minimum_password_length),
+            input_html: { autocomplete: 'new-password' } %>
+      <%= f.input :password_confirmation, required: true, input_html: { autocomplete: 'new-password' } %>
+    </div>
+
+    <div class="mt-6">
+      <%= f.button :submit, 'Sign up', class: 'bg-terra-dark text-white px-5 py-2 rounded-lg hover:bg-terra font-medium transition-colors' %>
+    </div>
+  <% end %>
+
+  <div class="mt-6 text-sm text-ink-light space-y-2">
+    <%= render 'devise/shared/links' %>
+  </div>
+</div>
+<% content_for(:page_title, 'Sign Up') %>

--- a/app/views/recipes/_show_content.html.erb
+++ b/app/views/recipes/_show_content.html.erb
@@ -40,9 +40,9 @@
         <div><span class="font-semibold text-ink">Makes:</span> <%= recipe.servings %> <%= recipe.serving_units %></div>
       <% end %>
       <div><span class="font-semibold text-ink">Created:</span> <%= l(recipe.created_at, format: :default) %></div>
-      <% if recipe.user_email.present? %>
+      <% if recipe.user_username.present? %>
         <div class="user">
-          by: <span class="badge inline-block bg-terra-faint text-terra-dark px-3 py-0.5 rounded-full text-xs font-medium"><%= link_to(recipe.user_email, root_path(filter_set: { author: recipe.user_email }), class: 'text-terra-dark no-underline hover:underline') %></span>
+          by: <span class="badge inline-block bg-terra-faint text-terra-dark px-3 py-0.5 rounded-full text-xs font-medium"><%= link_to(recipe.user_username, root_path(filter_set: { author: recipe.user_username }), class: 'text-terra-dark no-underline hover:underline') %></span>
         </div>
       <% end %>
     </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -13,6 +13,7 @@ en:
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account will be locked."
       not_found_in_database: "Invalid email or password."
+      pending_approval: "Your account is pending admin approval. You will be able to sign in once approved."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your account before continuing."
@@ -35,7 +36,7 @@ en:
     registrations:
       destroyed: "Bye! Your account was successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_inactive: "You have signed up successfully. Your account is pending admin approval — you will receive access once approved."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,14 @@ en:
       default: '%a, %b %-d, %Y'
       date: '%b %-d, %Y'
       short: '%B %d'
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            username:
+              format: 'can only contain letters, numbers, and underscores'
+
   ui:
     recipes:
       invalid_creation: We couldn't create that recipe. Please see below.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   namespace :admin do
+    resources :users, only: [:index] do
+      member { patch :approve }
+    end
     resources :recipes, only: [:index, :destroy] do
       member do
         patch :publish

--- a/db/migrate/20260223120000_add_username_and_approved_to_users.rb
+++ b/db/migrate/20260223120000_add_username_and_approved_to_users.rb
@@ -1,0 +1,7 @@
+class AddUsernameAndApprovedToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :username, :string, null: false, default: ''
+    add_column :users, :approved, :boolean, default: false, null: false
+    add_index  :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_21_190000) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -271,9 +271,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_21_190000) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.boolean "admin", default: false, null: false
+    t.string "username", default: "", null: false
+    t.boolean "approved", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,9 +34,11 @@ if Rails.env == 'development'
   admin = User.find_or_initialize_by(email: 'admin@example.com')
   if admin.new_record?
     admin.password = 'asdASD123!@#'
+    admin.username = 'admin'
     admin.skip_confirmation!
   end
-  admin.admin = true
+  admin.admin    = true
+  admin.approved = true
   admin.save!
 
   recipe = Recipe.create!(

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Admin::UsersController do
+  describe 'non-admin access' do
+    context 'when guest' do
+      it 'redirects from index' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when regular user' do
+      before { sign_in_user build(:user) }
+
+      it 'redirects from index' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'admin access' do
+    let(:admin) { build(:user, :admin) }
+
+    before { sign_in_user admin }
+
+    describe '#index' do
+      it 'is successful' do
+        get :index
+        expect(response).to be_successful
+      end
+
+      it 'assigns pending users (non-admin, unapproved)' do
+        pending_user  = create(:user, :pending)
+        approved_user = create(:user)
+        create(:user, :admin)
+
+        get :index
+
+        expect(assigns(:pending_users)).to include(pending_user)
+        expect(assigns(:pending_users)).not_to include(approved_user)
+      end
+
+      it 'assigns approved users (non-admin, approved)' do
+        pending_user  = create(:user, :pending)
+        approved_user = create(:user)
+
+        get :index
+
+        expect(assigns(:approved_users)).to include(approved_user)
+        expect(assigns(:approved_users)).not_to include(pending_user)
+      end
+    end
+
+    describe '#approve' do
+      it 'approves the user and redirects' do
+        user = create(:user, :pending)
+
+        patch :approve, params: { id: user.id }
+
+        expect(user.reload.approved).to be true
+        expect(response).to redirect_to(admin_users_path)
+      end
+
+      it 'sets a notice with the username' do
+        user = create(:user, :pending)
+
+        patch :approve, params: { id: user.id }
+
+        expect(flash[:notice]).to include(user.username)
+      end
+    end
+  end
+end

--- a/spec/features/user_manages_recipes_spec.rb
+++ b/spec/features/user_manages_recipes_spec.rb
@@ -119,7 +119,7 @@ Serve with raw jellybeans
     expect(recipe_on_page.cultural_influences).to include('american')
     expect(recipe_on_page.courses).to include('dinner')
     expect(recipe_on_page.dietary_restrictions).to include('low salt')
-    expect(recipe_on_page.user).to eq 'by: ' + user.email
+    expect(recipe_on_page.user).to eq 'by: ' + user.username
     expect(recipe_on_page.description).to have_css('em', text: 'description')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,8 @@ describe User do
 
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should validate_presence_of :email }
+  it { should validate_presence_of :username }
+  it { should validate_uniqueness_of(:username).case_insensitive }
   it { should have_many(:recipes) }
 
   context "email addresses" do
@@ -21,6 +23,51 @@ describe User do
       it "should reject invalid email addresses" do
         should_not allow_value(email).for(:email)
       end
+    end
+  end
+
+  context "usernames" do
+    it "accepts valid usernames" do
+      %w[alice alice_123 Bob_99 xyz].each do |u|
+        subject.username = u
+        subject.valid?
+        expect(subject.errors[:username]).to be_empty
+      end
+    end
+
+    it "rejects usernames with invalid characters" do
+      should_not allow_value('alice bob').for(:username)
+      should_not allow_value('alice!').for(:username)
+    end
+
+    it "rejects usernames shorter than 3 characters" do
+      should_not allow_value('ab').for(:username)
+    end
+
+    it "rejects usernames longer than 30 characters" do
+      should_not allow_value('a' * 31).for(:username)
+    end
+  end
+
+  context "approval" do
+    it "is active when approved" do
+      user = build(:user, approved: true)
+      expect(user.active_for_authentication?).to be true
+    end
+
+    it "is inactive when pending" do
+      user = build(:user, :pending)
+      expect(user.active_for_authentication?).to be false
+    end
+
+    it "returns :pending_approval as inactive_message when unapproved" do
+      user = build(:user, :pending)
+      expect(user.inactive_message).to eq :pending_approval
+    end
+
+    it "admins are always active regardless of approved flag" do
+      user = build(:user, :admin, approved: false)
+      expect(user.active_for_authentication?).to be true
     end
   end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,7 +1,8 @@
 # Read about factories at https://github.com/thoughtbot/factory_bot
 
 FactoryBot.define do
-  sequence(:email) { |n| "email#{n}@example.com" }
+  sequence(:email)    { |n| "email#{n}@example.com" }
+  sequence(:username) { |n| "user#{n}" }
   sequence(:name) { |n| "Recipe name #{n}" }
   sequence(:ingredient_name) { |n| "Ingredient name #{n}" }
   sequence(:cooking_method) { |n| "method #{n}" }
@@ -23,11 +24,17 @@ FactoryBot.define do
 
   factory :user do
     email
+    username
     password { 'asdASD123!@#' }
     confirmed_at { Time.current }
+    approved { true }
 
     trait :admin do
       admin { true }
+    end
+
+    trait :pending do
+      approved { false }
     end
   end
 


### PR DESCRIPTION
## Summary

- New users sign up with a unique public **username** (3–30 chars, letters/numbers/underscores) collected at registration via a custom Devise form
- Accounts require **admin approval** before the user can sign in; pending users see a clear message and cannot access recipe creation
- **Admin user management** at `/admin/users`: view pending and approved accounts, approve with one click
- Recipe author display and the author filter now use **username instead of email**
- Seeds and factories updated; admins bypass the approval gate by design

## What changed

- Migration: `username` (unique, not-null) and `approved` (boolean, default false) on users
- `User`: username validations, `active_for_authentication?` / `inactive_message` for Devise approval gate, `approved?` short-circuits for admins
- `ApplicationController`: `configure_permitted_parameters` for username on sign_up; `require_approved!` before_action
- `RecipesController`: `require_approved!` before new/create/edit/update
- `FilterSet`: author filter uses `users.username ilike ?`
- `Admin::UsersController` + routes
- Custom Devise registration view, admin users view
- Locales: `devise.failure.pending_approval` message
- Prompt: tightened field length constraints (`quantity` max 10 chars, description/directions caps)

## Test plan

- [ ] Sign up as a new user — confirm you land on a "pending approval" state and cannot sign in
- [ ] Sign in as admin, visit `/admin/users`, approve the new user
- [ ] Sign in as the newly approved user — confirm recipe create/edit works
- [ ] Confirm recipe show pages display username and the author filter link works
- [ ] `bundle exec rake` passes