### PR TITLE
Apply Command pattern to admin recipe transitions

### DIFF
--- a/app/commands/recipe_commands/destroy.rb
+++ b/app/commands/recipe_commands/destroy.rb
@@ -1,0 +1,12 @@
+module RecipeCommands
+  class Destroy
+    def initialize(recipe)
+      @recipe = recipe
+    end
+
+    def call
+      @recipe.destroy!
+      Result.new(success: true, message: 'Recipe deleted.')
+    end
+  end
+end

--- a/app/commands/recipe_commands/publish.rb
+++ b/app/commands/recipe_commands/publish.rb
@@ -1,0 +1,16 @@
+module RecipeCommands
+  class Publish
+    def initialize(recipe)
+      @recipe = recipe
+    end
+
+    def call
+      if @recipe.publishable?
+        @recipe.update!(status: 'published')
+        Result.new(success: true, message: 'Recipe published.')
+      else
+        Result.new(success: false, message: 'Recipe cannot be published from its current status.')
+      end
+    end
+  end
+end

--- a/app/commands/recipe_commands/reject.rb
+++ b/app/commands/recipe_commands/reject.rb
@@ -1,0 +1,12 @@
+module RecipeCommands
+  class Reject
+    def initialize(recipe)
+      @recipe = recipe
+    end
+
+    def call
+      @recipe.update!(status: 'rejected')
+      Result.new(success: true, message: 'Recipe rejected.')
+    end
+  end
+end

--- a/app/commands/recipe_commands/reprocess.rb
+++ b/app/commands/recipe_commands/reprocess.rb
@@ -1,0 +1,16 @@
+module RecipeCommands
+  class Reprocess
+    def initialize(recipe)
+      @recipe = recipe
+    end
+
+    def call
+      if @recipe.reprocessable?
+        MagicRecipeJob.perform_later(@recipe.id)
+        Result.new(success: true, message: 'Recipe re-enqueued for processing.')
+      else
+        Result.new(success: false, message: 'Recipe cannot be reprocessed from its current status.')
+      end
+    end
+  end
+end

--- a/app/commands/recipe_commands/result.rb
+++ b/app/commands/recipe_commands/result.rb
@@ -1,0 +1,5 @@
+module RecipeCommands
+  Result = Data.define(:success, :message) do
+    def flash_type = success ? :notice : :alert
+  end
+end

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -12,31 +12,23 @@ module Admin
     end
 
     def publish
-      if @recipe.publishable?
-        @recipe.update!(status: 'published')
-        redirect_to recipe_path(@recipe), notice: 'Recipe published.'
-      else
-        redirect_to recipe_path(@recipe), alert: 'Recipe cannot be published from its current status.'
-      end
+      result = RecipeCommands::Publish.new(@recipe).call
+      redirect_to recipe_path(@recipe), result.flash_type => result.message
     end
 
     def reject
-      @recipe.update!(status: 'rejected')
-      redirect_to recipe_path(@recipe), notice: 'Recipe rejected.'
+      result = RecipeCommands::Reject.new(@recipe).call
+      redirect_to recipe_path(@recipe), result.flash_type => result.message
     end
 
     def reprocess
-      if @recipe.reprocessable?
-        MagicRecipeJob.perform_later(@recipe.id)
-        redirect_to recipe_path(@recipe), notice: 'Recipe re-enqueued for processing.'
-      else
-        redirect_to recipe_path(@recipe), alert: 'Recipe cannot be reprocessed from its current status.'
-      end
+      result = RecipeCommands::Reprocess.new(@recipe).call
+      redirect_to recipe_path(@recipe), result.flash_type => result.message
     end
 
     def destroy
-      @recipe.destroy!
-      redirect_to admin_recipes_path, notice: 'Recipe deleted.'
+      result = RecipeCommands::Destroy.new(@recipe).call
+      redirect_to admin_recipes_path, result.flash_type => result.message
     end
 
     private

--- a/spec/commands/recipe_commands_spec.rb
+++ b/spec/commands/recipe_commands_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe RecipeCommands do
+  describe RecipeCommands::Publish do
+    context 'when recipe is publishable' do
+      it 'updates status to published and returns success' do
+        recipe = create(:recipe, status: 'review')
+        result = described_class.new(recipe).call
+
+        expect(recipe.reload.status).to eq('published')
+        expect(result.success).to be true
+        expect(result.message).to eq('Recipe published.')
+        expect(result.flash_type).to eq(:notice)
+      end
+    end
+
+    context 'when recipe is not publishable' do
+      it 'leaves status unchanged and returns failure' do
+        recipe = create(:recipe, :draft)
+        result = described_class.new(recipe).call
+
+        expect(recipe.reload.status).to eq('draft')
+        expect(result.success).to be false
+        expect(result.flash_type).to eq(:alert)
+      end
+    end
+  end
+
+  describe RecipeCommands::Reject do
+    it 'updates status to rejected and returns success' do
+      recipe = create(:recipe, status: 'review')
+      result = described_class.new(recipe).call
+
+      expect(recipe.reload.status).to eq('rejected')
+      expect(result.success).to be true
+      expect(result.message).to eq('Recipe rejected.')
+      expect(result.flash_type).to eq(:notice)
+    end
+  end
+
+  describe RecipeCommands::Reprocess do
+    context 'when recipe is reprocessable' do
+      it 'enqueues MagicRecipeJob and returns success' do
+        recipe = create(:recipe, :processing_failed, :magic)
+        result = nil
+
+        expect { result = described_class.new(recipe).call }
+          .to have_enqueued_job(MagicRecipeJob).with(recipe.id)
+
+        expect(result.success).to be true
+        expect(result.message).to eq('Recipe re-enqueued for processing.')
+      end
+    end
+
+    context 'when recipe is not reprocessable' do
+      it 'does not enqueue a job and returns failure' do
+        recipe = create(:recipe, :draft)
+        result = nil
+
+        expect { result = described_class.new(recipe).call }
+          .not_to have_enqueued_job(MagicRecipeJob)
+
+        expect(result.success).to be false
+        expect(result.flash_type).to eq(:alert)
+      end
+    end
+  end
+
+  describe RecipeCommands::Destroy do
+    it 'destroys the recipe and returns success' do
+      recipe = Recipe.includes(:images, :recipe_ingredients, :ingredients).find(create(:recipe).id)
+      result = described_class.new(recipe).call
+
+      expect { recipe.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(result.success).to be true
+      expect(result.message).to eq('Recipe deleted.')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extract `publish`, `reject`, `reprocess`, and `destroy` into command objects under `RecipeCommands::`, each with a `call` method returning an immutable `Result` value object (`success`, `message`, `flash_type`)
- `Admin::RecipesController` actions reduce to two lines each: execute the command, redirect with the result — guard logic and flash message strings move entirely out of the controller
- Adds `spec/commands/recipe_commands_spec.rb` with unit tests for each command, covering both success and guard-failure paths

## Test plan

- [ ] 279 examples, 0 failures (`bin/rake`)
- [ ] Existing admin recipes controller spec still passes
- [ ] No rubocop offenses
- [ ] Full CI suite passes